### PR TITLE
Lemmatize and tokenize a small subset of Latin and Greek inscriptions from CoNLL-U files

### DIFF
--- a/inscriptions/ISic000002.xml
+++ b/inscriptions/ISic000002.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../schematron/ircyr-checking.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">
@@ -9,7 +9,9 @@
                 <editor ref="#JP">Jonathan Prag</editor>
                 <principal ref="#JP">Jonathan Prag</principal>
                 <funder>John Fell OUP Research Fund</funder>
-	   <funder><ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref></funder>
+                <funder>
+                    <ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref>
+                </funder>
                 <respStmt>
                     <name xml:id="JP" ref="http://orcid.org/0000-0003-3819-8537">Jonathan Prag</name>
                     <resp>original data collection and editing</resp>
@@ -30,15 +32,15 @@
                     <name xml:id="MM">Michael Metcalfe</name>
                     <resp>museum data collection</resp>
                 </respStmt>
-	    <respStmt>
-     	       <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
-     	       <resp>standardisation of template and tidying up encoding</resp>
- 	   </respStmt>
+                <respStmt>
+                    <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
+                    <resp>standardisation of template and tidying up encoding</resp>
+                </respStmt>
                 <respStmt>
                     <name xml:id="LT" ref="https://orcid.org/0000-0002-2850-1064">Livia Tagliapietra</name>
                     <resp>improved reading in the text, modified apparatus and translation</resp>
                 </respStmt>
-	    <respStmt>
+                <respStmt>
                     <name xml:id="system">system</name>
                     <resp>automated or batch processes</resp>
                 </respStmt>
@@ -77,26 +79,29 @@
                     <physDesc>
                         <objectDesc>
                             <supportDesc>
-                                <support><p>Marble plaque, damaged on the right side</p>
+                                <support>
+                                    <p>Marble plaque, damaged on the right side</p>
                                     <material ana="#material.stone.marble" ref="http://www.eagle-network.eu/voc/material/lod/48.html">marble</material>
                                     <objectType ana="#object.plaque" ref="http://www.eagle-network.eu/voc/objtyp/lod/259.html">plaque</objectType>
-                                    <dimensions><!-- from ILPalermo -->
+                                    <dimensions>
+                                        <!-- from ILPalermo -->
                                         <height unit="cm">19</height>
                                         <width unit="cm">24.5</width>
                                         <depth unit="cm">3.5-4</depth>
                                     </dimensions>
                                 </support>
                                 <condition ana="#condition.damaged"/>
-		    </supportDesc>
+                            </supportDesc>
                             <layoutDesc>
                                 <layout>
                                     <rs ana="#execution.chiselled" ref="http://www.eagle-network.eu/voc/writing/lod/1">chiselled</rs>
-                                	<damage ana="#text_condition.incomplete"/>
-			</layout>
+                                    <damage ana="#text_condition.incomplete"/>
+                                </layout>
                             </layoutDesc>
                         </objectDesc>
                         <handDesc>
-                            <handNote><!--ILPalermo-->
+                            <handNote>
+                                <!--ILPalermo-->
                                 <locus from="line1" to="line1">Line 1</locus>
                                 <dimensions type="letterHeight">
                                     <height unit="mm">20</height>
@@ -125,7 +130,9 @@
                             </origPlace>
                             <origDate datingMethod="#julian" notBefore-custom="0201" notAfter-custom="0300" evidence="lettering" precision="low">3rd century CE</origDate>
                         </origin>
-                        <provenance type="found" subtype="discovered" notAfter="1833">From the Convento del Carmine, reported by Alessi as one of several find in the years preceding 1833<geo cert="medium">37.509637, 15.088925</geo></provenance>
+                        <provenance type="found" subtype="discovered" notAfter="1833">
+                            From the Convento del Carmine, reported by Alessi as one of several find in the years preceding 1833<geo cert="medium">37.509637, 15.088925</geo>
+                        </provenance>
                         <provenance type="observed" subtype="autopsied">None</provenance>
                         <acquisition/>
                     </history>
@@ -133,18 +140,18 @@
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
-             <p>Encoded following the latest EpiDoc guidelines</p>
-             <xi:include href="../alists/ISicily-taxonomies.xml">
-                 <xi:fallback>
-                     <p>Taxonomies for ISicily controlled values</p>
-                 </xi:fallback>
-             </xi:include>
-	  <xi:include href="../alists/charDecl.xml">
-	     <xi:fallback>
-	       <p>ISicily glyphs authority list</p>
-	     </xi:fallback>
-	   </xi:include>
-         </encodingDesc>
+            <p>Encoded following the latest EpiDoc guidelines</p>
+            <xi:include href="../alists/ISicily-taxonomies.xml">
+                <xi:fallback>
+                    <p>Taxonomies for ISicily controlled values</p>
+                </xi:fallback>
+            </xi:include>
+            <xi:include href="../alists/charDecl.xml">
+                <xi:fallback>
+                    <p>ISicily glyphs authority list</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
             <calendarDesc>
                 <calendar xml:id="julian">
@@ -152,17 +159,17 @@
                 </calendar>
             </calendarDesc>
             <langUsage>
-                <language ident="en">English</language> 
-                <language ident="it">Italian</language> 
-                <language ident="grc">Ancient Greek</language> 
-                <language ident="la">Latin</language> 
-                <language ident="he">Hebrew</language> 
+                <language ident="en">English</language>
+                <language ident="it">Italian</language>
+                <language ident="grc">Ancient Greek</language>
+                <language ident="la">Latin</language>
+                <language ident="he">Hebrew</language>
                 <language ident="phn">Phoenician</language>
                 <language ident="xpu">Punic</language>
-                <language ident="osc">Oscan</language> 
-                <language ident="xly">Elymian</language> 
-                <language ident="scx">Sikel</language>  
-                <language ident="sxc">Sikan</language>  
+                <language ident="osc">Oscan</language>
+                <language ident="xly">Elymian</language>
+                <language ident="scx">Sikel</language>
+                <language ident="sxc">Sikan</language>
             </langUsage>
             <textClass>
                 <keywords scheme="http://www.eagle-network.eu/voc/typeins.html">
@@ -174,17 +181,17 @@
             <listChange>
                 <change when="2016-12-03" who="#JCu">James Cummings autogenerated EpiDoc output from database</change>
                 <change when="2017-07-31" who="#JP">Jonathan Prag checked the EpiDoc</change>
-            	   <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>             	   
-            	   <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
+                <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
+                <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
                 <change when="2020-10-30" who="#JP">Jonathan Prag test relocated geo in origPlace; tidied up epidoc</change>
-            	<change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
-		<change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
-	    <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
-            	<change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
+                <change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
+                <change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
+                <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
+                <change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
                 <change when="2021-02-16" who="#JP">Jonathan Prag revised file from publications</change>
                 <change when="2021-06-30" who="#JP">Jonathan Prag modified the text and tagged named entities and added image</change>
                 <change when="2023-07-31" who="#LT">Livia Tagliapietra modified the text, the translation and apparatus</change>
-	</listChange>
+            </listChange>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -201,17 +208,38 @@
         <body>
             <div type="edition" xml:space="preserve" xml:lang="la" resp="#JP #LT">
                 <ab>
-                    <lb n="1"/><w><expan><abbr>D</abbr><ex>is</ex></expan></w> <g ref="#interpunct">·</g> <w><expan><abbr>M</abbr><ex>anibus</ex></expan></w> <g ref="#interpunct">·</g> <w><expan><abbr>s</abbr><ex>acrum</ex></expan></w>
-                    <lb n="2"/><persName type="attested"><name type="nomen">Lurius</name> <g ref="#interpunct">·</g> <name type="cognomen">Zosimus</name></persName>
-                    <lb n="3"/><w><expan><abbr>vix</abbr><ex>it</ex></expan></w> <g ref="#interpunct">·</g> <w>annis</w> <g ref="#interpunct">·</g> <num value="7">VII</num>
-                    <lb n="4"/><persName type="attested"><name type="nomen">Luria</name> <g ref="#interpunct">·</g> <name type="cognomen">Melant<supplied reason="undefined" evidence="previouseditor">hi</supplied> <supplied reason="lost" evidence="previouseditor"><g ref="#interpunct">·</g></supplied>
-                    <lb n="5" break="no"/><g ref="#interpunct">·</g> n</name></persName> <g ref="#interpunct">·</g> <w>suo</w> <g ref="#interpunct">·</g> <w>filio</w> <g ref="#interpunct">·</g> <w>fecit</w> <g ref="#interpunct">·</g>
+                    <lb n="1"/><w n="5"><expan><abbr>D</abbr><ex>is</ex></expan></w> <g ref="#interpunct">·</g> <w n="10"><expan><abbr>M</abbr><ex>anibus</ex></expan></w> <g ref="#interpunct">·</g> <w n="15"><expan><abbr>s</abbr><ex>acrum</ex></expan></w>
+                    <lb n="2"/><persName type="attested"><name type="nomen"><w n="20">Lurius</w></name> <g ref="#interpunct">·</g> <name type="cognomen"><w n="25">Zosimus</w></name></persName>
+                    <lb n="3"/><w n="30"><expan><abbr>vix</abbr><ex>it</ex></expan></w> <g ref="#interpunct">·</g> <w n="35">annis</w> <g ref="#interpunct">·</g> <num value="7"><w n="40">VII</w></num>
+                    <lb n="4"/><persName type="attested"><name type="nomen"><w n="45">Luria</w></name> <g ref="#interpunct">·</g> <name type="cognomen"><w n="50">Melant<supplied reason="undefined" evidence="previouseditor">hi</supplied><supplied reason="lost" evidence="previouseditor"><g ref="#interpunct">·</g></supplied>
+                    <lb n="5" break="no"/><g ref="#interpunct">·</g>n</w></name></persName> <g ref="#interpunct">·</g> <w n="55">suo</w> <g ref="#interpunct">·</g> <w n="60">filio</w> <g ref="#interpunct">·</g> <w n="65">fecit</w> <g ref="#interpunct">·</g>
+                </ab>
+            </div>
+            <div type="edition" subtype="simple-lemmatized">
+                <ab>
+                    <w n="5" lemma="dis">Dis</w>
+                    <w n="10" lemma="manes">Manibus</w>
+                    <w n="15" lemma="sacrum">sacrum</w>
+                    <w n="20" lemma="Lurius">Lurius</w>
+                    <w n="25" lemma="Zosimus">Zosimus</w>
+                    <w n="30" lemma="vivo">vixit</w>
+                    <w n="35" lemma="annus">annis</w>
+                    <w n="40" lemma="VII">VII</w>
+                    <w n="45" lemma="Luria">Luria</w>
+                    <w n="50" lemma="Melanthis">Melanthin</w>
+                    <w n="55" lemma="suus">suo</w>
+                    <w n="60" lemma="filius">filio</w>
+                    <w n="65" lemma="facio">fecit</w>
                 </ab>
             </div>
             <div type="apparatus" resp="#JP">
                 <listApp>
-                    <app loc="Line 4"><note>Alessi reported the text as intact and read MELANTHI· ; the text seems to have suffered damaged to the right margin since discovery</note></app>
-                    <app loc="Line 4-5"><note>Mommsen suggested 'potius Melanth(e) in suo, quam Melanthin(a) suo'.</note></app>
+                    <app loc="Line 4">
+                        <note>Alessi reported the text as intact and read MELANTHI· ; the text seems to have suffered damaged to the right margin since discovery</note>
+                    </app>
+                    <app loc="Line 4-5">
+                        <note>Mommsen suggested 'potius Melanth(e) in suo, quam Melanthin(a) suo'.</note>
+                    </app>
                 </listApp>
             </div>
             <div type="translation" xml:lang="en" resp="#JP">
@@ -235,25 +263,31 @@
                             <ref target="http://arachne.uni-koeln.de/books/CILv10pII1883">10.7075</ref>
                         </citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/GQN8UZSI"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10000589">https://biblio.inscriptiones.org/epig10000589</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10000589">https://biblio.inscriptiones.org/epig10000589</ref>
+                    </bibl>
                     <bibl type="corpus" n="ILMusPalermo">
                         <citedRange>2</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/FZWWPUD6"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002142">https://biblio.inscriptiones.org/epig10002142</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10002142">https://biblio.inscriptiones.org/epig10002142</ref>
+                    </bibl>
                     <bibl>
                         <author>Alessi</author>
                         <date>1833</date>
                         <citedRange>230</citedRange>
                         <ptr target="http://zotero.org/groups/382445/items/SRZQ4DSI"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002538">https://biblio.inscriptiones.org/epig10002538</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10002538">https://biblio.inscriptiones.org/epig10002538</ref>
+                    </bibl>
                     <bibl>
                         <author>Alessi</author>
                         <date>1833</date>
                         <citedRange>174</citedRange>
                         <ptr target="http://zotero.org/groups/382445/items/F986DASI"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002540">https://biblio.inscriptiones.org/epig10002540</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10002540">https://biblio.inscriptiones.org/epig10002540</ref>
+                    </bibl>
                 </listBibl>
-	   <listBibl type="discussion"><bibl/></listBibl>
+                <listBibl type="discussion">
+                    <bibl/>
+                </listBibl>
             </div>
         </body>
     </text>

--- a/inscriptions/ISic000045.xml
+++ b/inscriptions/ISic000045.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../schematron/ircyr-checking.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">
@@ -9,7 +9,9 @@
                 <editor ref="#JP">Jonathan Prag</editor>
                 <principal ref="#JP">Jonathan Prag</principal>
                 <funder>John Fell OUP Research Fund</funder>
-	   <funder><ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref></funder>
+                <funder>
+                    <ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref>
+                </funder>
                 <respStmt>
                     <name xml:id="JP" ref="http://orcid.org/0000-0003-3819-8537">Jonathan Prag</name>
                     <resp>original data collection and editing</resp>
@@ -30,11 +32,11 @@
                     <name xml:id="MM">Michael Metcalfe</name>
                     <resp>museum data collection</resp>
                 </respStmt>
-	    <respStmt>
-     	       <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
-     	       <resp>standardisation of template and tidying up encoding</resp>
- 	   </respStmt>
-	    <respStmt>
+                <respStmt>
+                    <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
+                    <resp>standardisation of template and tidying up encoding</resp>
+                </respStmt>
+                <respStmt>
                     <name xml:id="system">system</name>
                     <resp>automated or batch processes</resp>
                 </respStmt>
@@ -80,23 +82,25 @@
                                 <support>
                                     <material ana="#material.stone.marble" ref="http://www.eagle-network.eu/voc/material/lod/48.html">marble</material>
                                     <objectType/>
-                                    <dimensions><!--Default values and requires editing-->
+                                    <dimensions>
+                                        <!--Default values and requires editing-->
                                         <height unit="cm"/>
                                         <width unit="cm"/>
                                         <depth unit="cm"/>
                                     </dimensions>
                                 </support>
                                 <condition/>
-		    </supportDesc>
+                            </supportDesc>
                             <layoutDesc>
                                 <layout>
                                     <rs ana="#execution.chiselled" ref="http://www.eagle-network.eu/voc/writing/lod/1">chiselled</rs>
-                                	<damage/>
-			</layout>
+                                    <damage/>
+                                </layout>
                             </layoutDesc>
                         </objectDesc>
                         <handDesc>
-                            <handNote><!--Default value and requires editing-->
+                            <handNote>
+                                <!--Default value and requires editing-->
                                 <locus from="line1" to="line1">Line 1</locus>
                                 <dimensions type="letterHeight">
                                     <height unit="mm"/>
@@ -111,32 +115,33 @@
                     <history>
                         <origin>
                             <origPlace>
-                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462503">Syracusae</placeName>		
+                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462503">Syracusae</placeName>
                                 <placeName type="modern" ref="http://sws.geonames.org/2523083">Siracusa</placeName>
-                            	<geo>37.08415, 15.27628</geo>
-		</origPlace>
+                                <geo>37.08415, 15.27628</geo>
+                            </origPlace>
                             <origDate datingMethod="#julian" notBefore-custom="0101" notAfter-custom="0200" cert="low" precision="low">2nd century CE (?)</origDate>
                         </origin>
                         <provenance type="found">Original discovery not recorded.</provenance>
-                        <provenance type="observed" subtype="autopsied">None</provenance><!-- not seen on display in Palermo -->
+                        <provenance type="observed" subtype="autopsied">None</provenance>
+                        <!-- not seen on display in Palermo -->
                         <acquisition/>
                     </history>
                 </msDesc>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
-             <p>Encoded following the latest EpiDoc guidelines</p>
-             <xi:include href="../alists/ISicily-taxonomies.xml">
-                 <xi:fallback>
-                     <p>Taxonomies for ISicily controlled values</p>
-                 </xi:fallback>
-             </xi:include>
-	  <xi:include href="../alists/charDecl.xml">
-	     <xi:fallback>
-	       <p>ISicily glyphs authority list</p>
-	     </xi:fallback>
-	   </xi:include>
-         </encodingDesc>
+            <p>Encoded following the latest EpiDoc guidelines</p>
+            <xi:include href="../alists/ISicily-taxonomies.xml">
+                <xi:fallback>
+                    <p>Taxonomies for ISicily controlled values</p>
+                </xi:fallback>
+            </xi:include>
+            <xi:include href="../alists/charDecl.xml">
+                <xi:fallback>
+                    <p>ISicily glyphs authority list</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
             <calendarDesc>
                 <calendar xml:id="julian">
@@ -166,13 +171,13 @@
             <listChange>
                 <change when="2016-12-03" who="#JCu">James Cummings autogenerated EpiDoc output from database</change>
                 <change when="2018-01-20" who="#JP">Jonathan Prag encoded the text division</change>
-            	   <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
-            	   <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
-            	<change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
-		<change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
-	    <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
-            	<change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
-	</listChange>
+                <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
+                <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
+                <change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
+                <change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
+                <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
+                <change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
+            </listChange>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -183,27 +188,53 @@
             <graphic n="print" url="ISic000045.jpg" height="3680px" width="5520px">
                 <desc>I.Sicily with the permission of the Assessorato Regionale dei Beni Culturali e dell’Identità Siciliana - Dipartimento dei Beni Culturali e dell’Identità Siciliana</desc>
             </graphic>
-         </surface>
+        </surface>
     </facsimile>
     <text>
         <body>
-            <div type="edition" xml:space="preserve" xml:lang="la"><!-- needs checking against the ILPalermo edition -->
+            <div type="edition" xml:space="preserve" xml:lang="la">
+                <!-- needs checking against the ILPalermo edition -->
                 <ab>
-                    <lb n="1"/><supplied reason="lost"><expan><abbr>D</abbr><ex>is</ex></expan></supplied> <supplied reason="lost"><expan><abbr>M</abbr><ex>anibus</ex></expan></supplied> <expan><abbr>s</abbr><ex>acrum</ex></expan>
-                    <lb n="2"/><gap reason="lost" unit="character" extent="unknown"/>anthe
-                    <lb n="3"/><supplied reason="lost">vixit</supplied> <supplied reason="lost">a</supplied>nnos <hi rend="supraline">VII</hi>
-                    <lb n="4"/><gap reason="lost" unit="character" extent="unknown"/>nepoti
-                    <lb n="5"/><gap reason="lost" unit="character" extent="unknown"/>me <expan><abbr>fec</abbr><ex>it</ex></expan>
+                    <lb n="1"/><w n="5"><supplied reason="lost"><expan><abbr>D</abbr><ex>is</ex></expan></supplied></w> <w n="10"><supplied reason="lost"><expan><abbr>M</abbr><ex>anibus</ex></expan></supplied></w> <w n="15"><expan><abbr>s</abbr><ex>acrum</ex></expan></w>
+                    <lb n="2"/><gap reason="lost" unit="character" extent="unknown"/><w n="20">anthe</w>
+                    <lb n="3"/><w n="25"><supplied reason="lost">vixit</supplied></w> <w n="30"><supplied reason="lost">a</supplied>nnos</w> <w n="35"><hi rend="supraline">VII</hi></w>
+                    <lb n="4"/><gap reason="lost" unit="character" extent="unknown"/><w n="40">nepoti</w>
+                    <lb n="5"/><gap reason="lost" unit="character" extent="unknown"/><w n="45">me</w> <w n="50"><expan><abbr>fec</abbr><ex>it</ex></expan></w>
+                </ab>
+            </div>
+            <div type="edition" subtype="simple-lemmatized">
+                <ab>
+                    <w n="5" lemma="dis">Dis</w>
+                    <w n="10" lemma="manes">Manibus</w>
+                    <w n="15" lemma="sacrum">sacrum</w>
+                    <gap reason="lost" unit="character" extent="unknown"/>
+                    <w n="20" lemma="NOLEMMA">anthe</w>
+                    <w n="25" lemma="vivo">vixit</w>
+                    <w n="30" lemma="annus">annos</w>
+                    <w n="35" lemma="VII">VII</w>
+                    <gap reason="lost" unit="character" extent="unknown"/>
+                    <w n="40" lemma="nepos">nepoti</w>
+                    <gap reason="lost" unit="character" extent="unknown"/>
+                    <w n="45" lemma="NOLEMMA">me</w>
+                    <w n="50" lemma="facio">fecit</w>
                 </ab>
             </div>
             <div type="apparatus">
-                <listApp><app><note>Text of CIL</note></app></listApp>
+                <listApp>
+                    <app>
+                        <note>Text of CIL</note>
+                    </app>
+                </listApp>
             </div>
             <div type="translation">
-                <p><!--translation(s) - add @xml:lang for 'en' or 'it' to div--></p>
+                <p>
+                    <!--translation(s) - add @xml:lang for 'en' or 'it' to div-->
+                </p>
             </div>
             <div type="commentary">
-                <p><!--commentary--></p>
+                <p>
+                    <!--commentary-->
+                </p>
             </div>
             <div type="bibliography">
                 <listBibl type="edition">
@@ -212,14 +243,18 @@
                             <ref target="http://arachne.uni-koeln.de/books/CILv10pII1883">10.7158</ref>
                         </citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/GQN8UZSI"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10000589">https://biblio.inscriptiones.org/epig10000589</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10000589">https://biblio.inscriptiones.org/epig10000589</ref>
+                    </bibl>
                     <bibl type="corpus" n="ILMusPalermo">
                         <citedRange>46</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/FZWWPUD6"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002142">https://biblio.inscriptiones.org/epig10002142</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10002142">https://biblio.inscriptiones.org/epig10002142</ref>
+                    </bibl>
                     <bibl/>
                 </listBibl>
-	   <listBibl type="discussion"><bibl/></listBibl>
+                <listBibl type="discussion">
+                    <bibl/>
+                </listBibl>
             </div>
         </body>
     </text>

--- a/inscriptions/ISic000054.xml
+++ b/inscriptions/ISic000054.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../schematron/ircyr-checking.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">
@@ -9,7 +9,9 @@
                 <editor ref="#JP">Jonathan Prag</editor>
                 <principal ref="#JP">Jonathan Prag</principal>
                 <funder>John Fell OUP Research Fund</funder>
-	   <funder><ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref></funder>
+                <funder>
+                    <ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref>
+                </funder>
                 <respStmt>
                     <name xml:id="JP" ref="http://orcid.org/0000-0003-3819-8537">Jonathan Prag</name>
                     <resp>original data collection and editing</resp>
@@ -34,15 +36,15 @@
                     <name xml:id="TA" ref="https://orcid.org/0000-0001-8417-7089">Tuuli Ahlholm</name>
                     <resp>EpiDoc editing</resp>
                 </respStmt>
-	    <respStmt>
-     	       <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
-     	       <resp>standardisation of template and tidying up encoding</resp>
- 	   </respStmt>
+                <respStmt>
+                    <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
+                    <resp>standardisation of template and tidying up encoding</resp>
+                </respStmt>
                 <respStmt>
                     <name xml:id="VM" ref="https://orcid.org/0000-0002-7122-2511">Valentina Mignosa</name>
                     <resp>encoding text division</resp>
                 </respStmt>
-	    <respStmt>
+                <respStmt>
                     <name xml:id="system">system</name>
                     <resp>automated or batch processes</resp>
                 </respStmt>
@@ -82,26 +84,30 @@
                     <physDesc>
                         <objectDesc>
                             <supportDesc>
-                                <support><p>A marble plaque, intact above, below and left, broken lower right.</p>
+                                <support>
+                                    <p>A marble plaque, intact above, below and left, broken lower right.</p>
                                     <material ana="#material.stone.marble" ref="http://www.eagle-network.eu/voc/material/lod/48.html">marble</material>
                                     <objectType ana="#object.plaque" ref="https://www.eagle-network.eu/voc/objtyp/lod/259.html">plaque</objectType>
-                                    <dimensions><!--ILTermini/ILPalermo-->
+                                    <dimensions>
+                                        <!--ILTermini/ILPalermo-->
                                         <height unit="cm">34</height>
                                         <width unit="cm">40</width>
                                         <depth unit="cm">7</depth>
                                     </dimensions>
                                 </support>
                                 <condition/>
-		    </supportDesc>
+                            </supportDesc>
                             <layoutDesc>
-                                <layout><p>Text is approximately centered on the stone with five lines of varying length and spacing.</p>
+                                <layout>
+                                    <p>Text is approximately centered on the stone with five lines of varying length and spacing.</p>
                                     <rs ana="#execution.chiselled" ref="http://www.eagle-network.eu/voc/writing/lod/1">chiselled</rs>
-                                	<damage/>
-			</layout>
+                                    <damage/>
+                                </layout>
                             </layoutDesc>
                         </objectDesc>
                         <handDesc>
-                            <handNote><!--ILTermini-->
+                            <handNote>
+                                <!--ILTermini-->
                                 <locus from="line1" to="line1">Line 1</locus>
                                 <dimensions type="letterHeight">
                                     <height unit="mm">55-60</height>
@@ -128,10 +134,10 @@
                     <history>
                         <origin>
                             <origPlace>
-                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462513">Thermae Himeraeae</placeName>		
+                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462513">Thermae Himeraeae</placeName>
                                 <placeName type="modern" ref="http://sws.geonames.org/6539140">Termini Imerese</placeName>
-                            	<geo>37.98365, 13.69555</geo>
-		</origPlace>
+                                <geo>37.98365, 13.69555</geo>
+                            </origPlace>
                             <origDate datingMethod="#julian" notBefore-custom="0001" notAfter-custom="0200">first or second century CE</origDate>
                         </origin>
                         <provenance type="found" subtype="discovered" notAfter="1873">Found in Termini Imerese by one Giuseppe Di Giorgi, and acquired from him by Palermo Museum in 1873, along with several others (incl. ISic000055)</provenance>
@@ -142,18 +148,18 @@
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
-             <p>Encoded following the latest EpiDoc guidelines</p>
-             <xi:include href="../alists/ISicily-taxonomies.xml">
-                 <xi:fallback>
-                     <p>Taxonomies for ISicily controlled values</p>
-                 </xi:fallback>
-             </xi:include>
-	  <xi:include href="../alists/charDecl.xml">
-	     <xi:fallback>
-	       <p>ISicily glyphs authority list</p>
-	     </xi:fallback>
-	   </xi:include>
-         </encodingDesc>
+            <p>Encoded following the latest EpiDoc guidelines</p>
+            <xi:include href="../alists/ISicily-taxonomies.xml">
+                <xi:fallback>
+                    <p>Taxonomies for ISicily controlled values</p>
+                </xi:fallback>
+            </xi:include>
+            <xi:include href="../alists/charDecl.xml">
+                <xi:fallback>
+                    <p>ISicily glyphs authority list</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
             <calendarDesc>
                 <calendar xml:id="julian">
@@ -183,16 +189,16 @@
             <listChange>
                 <change when="2016-12-03" who="#JCu">James Cummings autogenerated EpiDoc output from database</change>
                 <change when="2018-05-10" who="#TA">Tuuli Ahlholm cleaned up the autogenerated text and added an apparatus and translation</change>
-            	   <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
+                <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
                 <change when="2020-10-06" who="#VM">Valentina Mignosa encoded text division</change>
-            	   <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
-            	<change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
-		<change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
-	    <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
-            	<change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
+                <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
+                <change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
+                <change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
+                <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
+                <change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
                 <change when="2021-06-30" who="#JP">Jonathan Prag tagged named entities</change>
                 <change when="2024-05-02" who="#JP">Jonathan Prag revised from publication and photograph and added image.</change>
-	</listChange>
+            </listChange>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -203,29 +209,46 @@
             <graphic n="print" url="ISic000054.jpg" height="3680px" width="5520px">
                 <desc>I.Sicily with the permission of the Assessorato Regionale dei Beni Culturali e dell’Identità Siciliana - Dipartimento dei Beni Culturali e dell’Identità Siciliana; photo J. Prag 2022-05-23.</desc>
             </graphic>
-         </surface>
+        </surface>
     </facsimile>
     <text>
         <body>
             <div type="edition" xml:space="preserve" xml:lang="la" resp="#TA #JP">
                 <ab>
-                    <lb n="1"/><persName type="attested"><name type="nomen">Clovatia</name> <g ref="#interpunct">·</g> <persName type="attested"><name type="libertinatio"><expan><abbr>C</abbr><ex>ai</ex></expan></name></persName> <g ref="#interpunct">·</g> <w><expan><abbr>l</abbr><ex>iberta</ex></expan></w>
-                    <lb n="2"/><name type="cognomen">Tertia</name></persName>
-                    <lb n="3"/><persName type="attested"><name type="nomen">Clovatiae</name> <g ref="#interpunct">·</g> <persName type="attested"><name type="libertinatio"><expan><abbr>C</abbr><ex>ai</ex></expan></name></persName> <g ref="#interpunct">·</g> <w><expan><abbr>l</abbr><ex>ibertae</ex></expan></w>
-                    <lb n="4"/><name type="cognomen">Optatae</name></persName> <g ref="#interpunct">·</g> <w><expan><abbr>f</abbr><ex>iliae</ex></expan></w> <g ref="#interpunct">·</g> <w>et</w>
-                    <lb n="5"/><w>sibi</w>
+                    <lb n="1"/><persName type="attested"><name type="nomen"><w n="5">Clovatia</w></name> <g ref="#interpunct">·</g> <persName type="attested"><name type="libertinatio"><w n="10"><expan><abbr>C</abbr><ex>ai</ex></expan></w></name></persName> <g ref="#interpunct">·</g> <w n="15"><expan><abbr>l</abbr><ex>iberta</ex></expan></w>
+                    <lb n="2"/><name type="cognomen"><w n="20">Tertia</w></name></persName>
+                    <lb n="3"/><persName type="attested"><name type="nomen"><w n="25">Clovatiae</w></name> <g ref="#interpunct">·</g> <persName type="attested"><name type="libertinatio"><w n="30"><expan><abbr>C</abbr><ex>ai</ex></expan></w></name></persName> <g ref="#interpunct">·</g> <w n="35"><expan><abbr>l</abbr><ex>ibertae</ex></expan></w>
+                    <lb n="4"/><name type="cognomen"><w n="40">Optatae</w></name></persName> <g ref="#interpunct">·</g> <w n="45"><expan><abbr>f</abbr><ex>iliae</ex></expan></w> <g ref="#interpunct">·</g> <w n="50">et</w>
+                    <lb n="5"/><w n="55">sibi</w>
+                </ab>
+            </div>
+            <div type="edition" subtype="simple-lemmatized">
+                <ab>
+                    <w n="5" lemma="Clovatia">Clovatia</w>
+                    <w n="10" lemma="Caius">Cai</w>
+                    <w n="15" lemma="liberta">liberta</w>
+                    <w n="20" lemma="Tertia">Tertia</w>
+                    <w n="25" lemma="Clovatia">Clovatiae</w>
+                    <w n="30" lemma="Caius">Cai</w>
+                    <w n="35" lemma="liberta">libertae</w>
+                    <w n="40" lemma="Optata">Optatae</w>
+                    <w n="45" lemma="filia">filiae</w>
+                    <w n="50" lemma="et">et</w>
+                    <w n="55" lemma="se">sibi</w>
                 </ab>
             </div>
             <div type="apparatus">
                 <listApp>
-                    <app><note>Text from photograph</note></app>
+                    <app>
+                        <note>Text from photograph</note>
+                    </app>
                 </listApp>
             </div>
             <div type="translation" xml:lang="en" resp="#TA">
                 <p>Clovatia Tertia, freedwoman of Gaius, (set this up) for Clovatia Optata, freedwoman of Gaius, her daughter, and for herself.</p>
             </div>
             <div type="commentary">
-                <p></p>
+                <p/>
             </div>
             <div type="bibliography">
                 <listBibl type="edition">
@@ -234,18 +257,23 @@
                             <ref target="http://arachne.uni-koeln.de/item/buchseite/650798">10.7393</ref>
                         </citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/GQN8UZSI"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10000589">https://biblio.inscriptiones.org/epig10000589</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10000589">https://biblio.inscriptiones.org/epig10000589</ref>
+                    </bibl>
                     <bibl type="corpus" n="ILMusPalermo">
                         <citedRange>57</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/FZWWPUD6"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002142">https://biblio.inscriptiones.org/epig10002142</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10002142">https://biblio.inscriptiones.org/epig10002142</ref>
+                    </bibl>
                     <bibl type="corpus" n="ILMusTermini">
                         <citedRange>75</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/JCV85C79"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002137">https://biblio.inscriptiones.org/epig10002137</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10002137">https://biblio.inscriptiones.org/epig10002137</ref>
+                    </bibl>
                     <bibl/>
                 </listBibl>
-	   <listBibl type="discussion"><bibl/></listBibl>
+                <listBibl type="discussion">
+                    <bibl/>
+                </listBibl>
             </div>
         </body>
     </text>

--- a/inscriptions/ISic000056.xml
+++ b/inscriptions/ISic000056.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../schematron/ircyr-checking.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">
@@ -9,7 +9,9 @@
                 <editor ref="#JP">Jonathan Prag</editor>
                 <principal ref="#JP">Jonathan Prag</principal>
                 <funder>John Fell OUP Research Fund</funder>
-	   <funder><ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref></funder>
+                <funder>
+                    <ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref>
+                </funder>
                 <respStmt>
                     <name xml:id="JP" ref="http://orcid.org/0000-0003-3819-8537">Jonathan Prag</name>
                     <resp>original data collection and editing</resp>
@@ -34,10 +36,10 @@
                     <name xml:id="TA" ref="https://orcid.org/0000-0001-8417-7089">Tuuli Ahlholm</name>
                     <resp>EpiDoc editing</resp>
                 </respStmt>
-	    <respStmt>
-     	       <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
-     	       <resp>standardisation of template and tidying up encoding</resp>
- 	   </respStmt>
+                <respStmt>
+                    <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
+                    <resp>standardisation of template and tidying up encoding</resp>
+                </respStmt>
                 <respStmt>
                     <name xml:id="VM" ref="https://orcid.org/0000-0002-7122-2511">Valentina Mignosa</name>
                     <resp>encoding text division</resp>
@@ -46,7 +48,7 @@
                     <name xml:id="MR">Maria Randazzo</name>
                     <resp>autopsy and editing</resp>
                 </respStmt>
-	    <respStmt>
+                <respStmt>
                     <name xml:id="system">system</name>
                     <resp>automated or batch processes</resp>
                 </respStmt>
@@ -86,7 +88,8 @@
                     <physDesc>
                         <objectDesc>
                             <supportDesc>
-                                <support><p>Quadrangular plaque of grey marble with white veining. Minor damage to the lower right corner only, which does not affect the epigraphic text. The edges are all cut regularly. The lower edge has two small holes (8 mm), probably of modern date for display.</p>
+                                <support>
+                                    <p>Quadrangular plaque of grey marble with white veining. Minor damage to the lower right corner only, which does not affect the epigraphic text. The edges are all cut regularly. The lower edge has two small holes (8 mm), probably of modern date for display.</p>
                                     <material ana="#material.stone.marble" ref="http://www.eagle-network.eu/voc/material/lod/48.html">marble</material>
                                     <objectType ana="#object.plaque" ref="https://www.eagle-network.eu/voc/objtyp/lod/259.html">plaque</objectType>
                                     <dimensions>
@@ -96,16 +99,18 @@
                                     </dimensions>
                                 </support>
                                 <condition ana="#condition.damaged"/>
-		    </supportDesc>
+                            </supportDesc>
                             <layoutDesc>
-                                <layout><p>The epigraphic field, of three lines of Latin letters, decreasing in size, is approximately centred on the plaque, with an upper margin of 4.5cm, a lower margin of 1.8cm, left margin of 2.5 cm and right margin of 2 cm.</p>
+                                <layout>
+                                    <p>The epigraphic field, of three lines of Latin letters, decreasing in size, is approximately centred on the plaque, with an upper margin of 4.5cm, a lower margin of 1.8cm, left margin of 2.5 cm and right margin of 2 cm.</p>
                                     <rs ana="#execution.chiselled" ref="http://www.eagle-network.eu/voc/writing/lod/1">chiselled</rs>
-                                	<damage ana="#text_condition.complete"/>
-			</layout>
+                                    <damage ana="#text_condition.complete"/>
+                                </layout>
                             </layoutDesc>
                         </objectDesc>
                         <handDesc>
-                            <handNote><p>The letters are v-cut in a tall and narrow module, with triangular serifs. The letters are regularly spaced, with the size / spacing decreasing towards the right and from line 1 to line 3. A has a cross bar descending to the left; M has four full length strokes, all off vertical. Interpuncts in the form of ivy-leaf (somewhat various in form) at the end of each line; plainer interpuncts between words in line 3.</p>
+                            <handNote>
+                                <p>The letters are v-cut in a tall and narrow module, with triangular serifs. The letters are regularly spaced, with the size / spacing decreasing towards the right and from line 1 to line 3. A has a cross bar descending to the left; M has four full length strokes, all off vertical. Interpuncts in the form of ivy-leaf (somewhat various in form) at the end of each line; plainer interpuncts between words in line 3.</p>
                                 <locus from="line1" to="line1">Line 1</locus>
                                 <dimensions type="letterHeight">
                                     <height unit="mm">55</height>
@@ -132,10 +137,10 @@
                     <history>
                         <origin>
                             <origPlace>
-                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462513" cert="low">Thermae Himeraeae</placeName>		
+                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462513" cert="low">Thermae Himeraeae</placeName>
                                 <placeName type="modern" ref="http://sws.geonames.org/6539140">Termini Imerese</placeName>
-                            	<geo>37.98365, 13.69555</geo>
-		</origPlace>
+                                <geo>37.98365, 13.69555</geo>
+                            </origPlace>
                             <origDate datingMethod="#julian" notBefore-custom="0001" notAfter-custom="0100" precision="low">1st century CE</origDate>
                         </origin>
                         <provenance type="found" subtype="first-seen" when="1867">First recorded in Termini Imerese in 1867 by Benndorf who saw it at an antique dealer, who subsequently sold it to Palermo museum.</provenance>
@@ -146,18 +151,18 @@
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
-             <p>Encoded following the latest EpiDoc guidelines</p>
-             <xi:include href="../alists/ISicily-taxonomies.xml">
-                 <xi:fallback>
-                     <p>Taxonomies for ISicily controlled values</p>
-                 </xi:fallback>
-             </xi:include>
-	  <xi:include href="../alists/charDecl.xml">
-	     <xi:fallback>
-	       <p>ISicily glyphs authority list</p>
-	     </xi:fallback>
-	   </xi:include>
-         </encodingDesc>
+            <p>Encoded following the latest EpiDoc guidelines</p>
+            <xi:include href="../alists/ISicily-taxonomies.xml">
+                <xi:fallback>
+                    <p>Taxonomies for ISicily controlled values</p>
+                </xi:fallback>
+            </xi:include>
+            <xi:include href="../alists/charDecl.xml">
+                <xi:fallback>
+                    <p>ISicily glyphs authority list</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
             <calendarDesc>
                 <calendar xml:id="julian">
@@ -187,16 +192,16 @@
             <listChange>
                 <change when="2016-12-03" who="#JCu">James Cummings autogenerated EpiDoc output from database</change>
                 <change when="2018-05-11" who="#TA">Tuuli Ahlholm cleaned up the autogenerated text and added an apparatus</change>
-            	   <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
+                <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
                 <change when="2020-10-07" who="#VM">Valentina Mignosa encoded text division</change>
-            	   <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
-            	<change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
-	<change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
-	    <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
-            	<change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
+                <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
+                <change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
+                <change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
+                <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
+                <change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
                 <change when="2022-05-23" who="#MR">Maria Randazzo edited file from autopsy and added commentary</change>
                 <change when="2022-06-16" who="#JP">Jonathan Prag edited and added image</change>
-	</listChange>
+            </listChange>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -213,14 +218,25 @@
         <body>
             <div type="edition" xml:space="preserve" xml:lang="la" resp="#MR">
                 <ab>
-                        <lb n="1"/><persName type="attested"> <name type="nomen"><expan><abbr>Claud</abbr><ex>ius</ex></expan></name> <g ref="#ivy-leaf">❦</g>
-                        <lb n="2"/><name type="cognomen">Maximus</name></persName> <g ref="#ivy-leaf">❦</g> 
-                        <lb n="3"/><w><expan><abbr>vix</abbr><ex>it</ex></expan></w>  <g ref="#ivy-leaf">❦</g>  <w><expan><abbr>an</abbr><ex>nis</ex></expan></w> <unclear><g ref="#ivy-leaf">❦</g></unclear> <num value="17">XVII</num> <g ref="#ivy-leaf">❦</g>
+                    <lb n="1"/><persName type="attested"><name type="nomen"><w n="5"><expan><abbr>Claud</abbr><ex>ius</ex></expan></w></name> <g ref="#ivy-leaf">❦</g>
+                    <lb n="2"/><name type="cognomen"><w n="10">Maximus</w></name></persName> <g ref="#ivy-leaf">❦</g>
+                    <lb n="3"/><w n="15"><expan><abbr>vix</abbr><ex>it</ex></expan></w> <g ref="#ivy-leaf">❦</g> <w n="20"><expan><abbr>an</abbr><ex>nis</ex></expan></w> <unclear><g ref="#ivy-leaf">❦</g></unclear><num value="17"><w n="25">XVII</w></num> <g ref="#ivy-leaf">❦</g>
+                </ab>
+            </div>
+            <div type="edition" subtype="simple-lemmatized">
+                <ab>
+                    <w n="5" lemma="Claudius">Claudius</w>
+                    <w n="10" lemma="Maximus">Maximus</w>
+                    <w n="15" lemma="vivo">vixit</w>
+                    <w n="20" lemma="annus">annis</w>
+                    <w n="25" lemma="XVII">XVII</w>
                 </ab>
             </div>
             <div type="apparatus">
                 <listApp>
-                    <app><note>Text from autopsy</note></app>   
+                    <app>
+                        <note>Text from autopsy</note>
+                    </app>
                 </listApp>
             </div>
             <div type="translation" xml:lang="it" resp="#MR">
@@ -240,18 +256,23 @@
                             <ref target="http://arachne.uni-koeln.de/item/buchseite/650798">10.7391</ref>
                         </citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/GQN8UZSI"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10000589">https://biblio.inscriptiones.org/epig10000589</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10000589">https://biblio.inscriptiones.org/epig10000589</ref>
+                    </bibl>
                     <bibl type="corpus" n="ILMusPalermo">
                         <citedRange>56</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/FZWWPUD6"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002142">https://biblio.inscriptiones.org/epig10002142</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10002142">https://biblio.inscriptiones.org/epig10002142</ref>
+                    </bibl>
                     <bibl type="corpus" n="ILMusTermini">
                         <citedRange>72</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/JCV85C79"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002137">https://biblio.inscriptiones.org/epig10002137</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10002137">https://biblio.inscriptiones.org/epig10002137</ref>
+                    </bibl>
                     <bibl/>
                 </listBibl>
-	   <listBibl type="discussion"><bibl/></listBibl>
+                <listBibl type="discussion">
+                    <bibl/>
+                </listBibl>
             </div>
         </body>
     </text>

--- a/inscriptions/ISic000057.xml
+++ b/inscriptions/ISic000057.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../schematron/ircyr-checking.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">
@@ -9,7 +9,9 @@
                 <editor ref="#JP">Jonathan Prag</editor>
                 <principal ref="#JP">Jonathan Prag</principal>
                 <funder>John Fell OUP Research Fund</funder>
-	   <funder><ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref></funder>
+                <funder>
+                    <ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref>
+                </funder>
                 <respStmt>
                     <name xml:id="JP" ref="http://orcid.org/0000-0003-3819-8537">Jonathan Prag</name>
                     <resp>original data collection and editing</resp>
@@ -34,15 +36,15 @@
                     <name xml:id="TA" ref="https://orcid.org/0000-0001-8417-7089">Tuuli Ahlholm</name>
                     <resp>EpiDoc editing</resp>
                 </respStmt>
-	    <respStmt>
-     	       <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
-     	       <resp>standardisation of template and tidying up encoding</resp>
- 	   </respStmt>
+                <respStmt>
+                    <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
+                    <resp>standardisation of template and tidying up encoding</resp>
+                </respStmt>
                 <respStmt>
                     <name xml:id="VM" ref="https://orcid.org/0000-0002-7122-2511">Valentina Mignosa</name>
                     <resp>encoding text division</resp>
                 </respStmt>
-	    <respStmt>
+                <respStmt>
                     <name xml:id="system">system</name>
                     <resp>automated or batch processes</resp>
                 </respStmt>
@@ -87,23 +89,25 @@
                             <supportDesc>
                                 <support>
                                     <material ana="#material.stone.limestone" ref="http://www.eagle-network.eu/voc/material/lod/66.html">limestone</material>
-                                    <dimensions><!--Default values and requires editing-->
+                                    <dimensions>
+                                        <!--Default values and requires editing-->
                                         <height unit="cm"/>
                                         <width unit="cm"/>
                                         <depth unit="cm"/>
                                     </dimensions>
                                 </support>
                                 <condition/>
-		    </supportDesc>
+                            </supportDesc>
                             <layoutDesc>
                                 <layout>
                                     <rs ana="#execution.chiselled" ref="http://www.eagle-network.eu/voc/writing/lod/1">chiselled</rs>
-                                	<damage/>
-			</layout>
+                                    <damage/>
+                                </layout>
                             </layoutDesc>
                         </objectDesc>
                         <handDesc>
-                            <handNote><!--Default value and requires editing-->
+                            <handNote>
+                                <!--Default value and requires editing-->
                                 <locus from="line1" to="line1">Line 1</locus>
                                 <dimensions type="letterHeight">
                                     <height unit="mm"/>
@@ -118,10 +122,10 @@
                     <history>
                         <origin>
                             <origPlace>
-                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462513">Thermae Himeraeae</placeName>		
+                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462513">Thermae Himeraeae</placeName>
                                 <placeName type="modern" ref="http://sws.geonames.org/6539140">Termini Imerese</placeName>
-                            	<geo>37.98365, 13.69555</geo>
-		</origPlace>
+                                <geo>37.98365, 13.69555</geo>
+                            </origPlace>
                             <origDate datingMethod="#julian" notBefore-custom="0001" notAfter-custom="0300" cert="low">Imperial</origDate>
                         </origin>
                         <provenance type="found">Original discovery not recorded.</provenance>
@@ -132,18 +136,18 @@
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
-             <p>Encoded following the latest EpiDoc guidelines</p>
-             <xi:include href="../alists/ISicily-taxonomies.xml">
-                 <xi:fallback>
-                     <p>Taxonomies for ISicily controlled values</p>
-                 </xi:fallback>
-             </xi:include>
-	  <xi:include href="../alists/charDecl.xml">
-	     <xi:fallback>
-	       <p>ISicily glyphs authority list</p>
-	     </xi:fallback>
-	   </xi:include>
-         </encodingDesc>
+            <p>Encoded following the latest EpiDoc guidelines</p>
+            <xi:include href="../alists/ISicily-taxonomies.xml">
+                <xi:fallback>
+                    <p>Taxonomies for ISicily controlled values</p>
+                </xi:fallback>
+            </xi:include>
+            <xi:include href="../alists/charDecl.xml">
+                <xi:fallback>
+                    <p>ISicily glyphs authority list</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
             <calendarDesc>
                 <calendar xml:id="julian">
@@ -174,14 +178,14 @@
                 <change when="2016-12-03" who="#JCu">James Cummings autogenerated EpiDoc output from database</change>
                 <change when="2018-05-11" who="#TA">Tuuli Ahlholm cleaned up the autogenerated text and added an apparatus</change>
                 <change when="2020-09-14" who="#JP">Jonathan Prag added bibl ref</change>
-            	   <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
+                <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
                 <change when="2020-10-07" who="#VM">Valentina Mignosa encoded text division</change>
-            	   <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
-            	<change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
-		<change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
-	    <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
-            	<change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
-	</listChange>
+                <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
+                <change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
+                <change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
+                <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
+                <change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
+            </listChange>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -192,29 +196,49 @@
             <graphic n="print" url="ISic000057.jpg" height="3680px" width="5520px">
                 <desc>I.Sicily with the permission of the Assessorato Regionale dei Beni Culturali e dell’Identità Siciliana - Dipartimento dei Beni Culturali e dell’Identità Siciliana</desc>
             </graphic>
-         </surface>
+        </surface>
     </facsimile>
     <text>
         <body>
             <div type="edition" xml:space="preserve" xml:lang="la" resp="#TA">
                 <ab>
-                    <lb n="1"/><expan><abbr>Q</abbr><ex>uintus</ex></expan> <g ref="#interpunct">·</g> Fabius <g ref="#interpunct">·</g> <expan><abbr>Q</abbr><ex>uinti</ex></expan> <g ref="#interpunct">·</g> <expan><abbr>l</abbr><ex>ibertus</ex></expan>
-                    <lb n="2"/>Isio
-                    <lb n="3"/>Laeliae <g ref="#interpunct">·</g> <expan><abbr>D</abbr><ex>ecimi</ex></expan> <g ref="#interpunct">·</g> <expan><abbr>l</abbr><ex>ibertae</ex></expan> <g ref="#interpunct">·</g> Coprillae
-                    <lb n="4"/>uxori
+                    <lb n="1"/><w n="5"><expan><abbr>Q</abbr><ex>uintus</ex></expan></w> <g ref="#interpunct">·</g> <w n="10">Fabius</w> <g ref="#interpunct">·</g> <w n="15"><expan><abbr>Q</abbr><ex>uinti</ex></expan></w> <g ref="#interpunct">·</g> <w n="20"><expan><abbr>l</abbr><ex>ibertus</ex></expan></w>
+                    <lb n="2"/><w n="25">Isio</w>
+                    <lb n="3"/><w n="30">Laeliae</w> <g ref="#interpunct">·</g> <w n="35"><expan><abbr>D</abbr><ex>ecimi</ex></expan></w> <g ref="#interpunct">·</g> <w n="40"><expan><abbr>l</abbr><ex>ibertae</ex></expan></w> <g ref="#interpunct">·</g> <w n="45">Coprillae</w>
+                    <lb n="4"/><w n="50">uxori</w>
+                </ab>
+            </div>
+            <div type="edition" subtype="simple-lemmatized">
+                <ab>
+                    <w n="5" lemma="Quintus">Quintus</w>
+                    <w n="10" lemma="Fabius">Fabius</w>
+                    <w n="15" lemma="Quintus">Quinti</w>
+                    <w n="20" lemma="libertus">libertus</w>
+                    <w n="25" lemma="Isius">Isio</w>
+                    <w n="30" lemma="Laelia">Laeliae</w>
+                    <w n="35" lemma="Decimus">Decimi</w>
+                    <w n="40" lemma="liberta">libertae</w>
+                    <w n="45" lemma="Coprilla">Coprillae</w>
+                    <w n="50" lemma="uxor">uxori</w>
                 </ab>
             </div>
             <div type="apparatus">
                 <listApp>
-                    <app><note>Text of ILTermini</note></app>
+                    <app>
+                        <note>Text of ILTermini</note>
+                    </app>
                 </listApp>
             </div>
             <div type="translation">
-                <p><!--translation(s) - add @xml:lang for 'en' or 'it' to div--></p>
+                <p>
+                    <!--translation(s) - add @xml:lang for 'en' or 'it' to div-->
+                </p>
             </div>
             <div type="commentary">
-                <p><!--commented out pending revision-->
-                    <!--Q.Fabius Q.l.Isio erected for his wife Laelia D.l.Coprilla - Isio known elsewhere in Sic, incl. in Latin; Fabius present on island from late Rep.; Laelia (fem. form) is only in this inscr. for Sic epig.--></p>
+                <p>
+                    <!--commented out pending revision-->
+                    <!--Q.Fabius Q.l.Isio erected for his wife Laelia D.l.Coprilla - Isio known elsewhere in Sic, incl. in Latin; Fabius present on island from late Rep.; Laelia (fem. form) is only in this inscr. for Sic epig.-->
+                </p>
             </div>
             <div type="bibliography">
                 <listBibl type="edition">
@@ -223,23 +247,29 @@
                             <ref target="http://arachne.uni-koeln.de/item/buchseite/650799">10.7403</ref>
                         </citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/GQN8UZSI"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10000589">https://biblio.inscriptiones.org/epig10000589</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10000589">https://biblio.inscriptiones.org/epig10000589</ref>
+                    </bibl>
                     <bibl type="corpus" n="ILMusPalermo">
                         <citedRange>58</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/FZWWPUD6"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002142">https://biblio.inscriptiones.org/epig10002142</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10002142">https://biblio.inscriptiones.org/epig10002142</ref>
+                    </bibl>
                     <bibl type="corpus" n="ILMusTermini">
                         <citedRange>96</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/JCV85C79"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002137">https://biblio.inscriptiones.org/epig10002137</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10002137">https://biblio.inscriptiones.org/epig10002137</ref>
+                    </bibl>
                     <bibl>
                         <author>Manganaro</author>
                         <date>1988</date>
                         <citedRange>50</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/RZSFKACR"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001427">https://biblio.inscriptiones.org/epig10001427</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001427">https://biblio.inscriptiones.org/epig10001427</ref>
+                    </bibl>
                 </listBibl>
-	   <listBibl type="discussion"><bibl/></listBibl>
+                <listBibl type="discussion">
+                    <bibl/>
+                </listBibl>
             </div>
         </body>
     </text>

--- a/inscriptions/ISic000059.xml
+++ b/inscriptions/ISic000059.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../schematron/ircyr-checking.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">
@@ -9,7 +9,9 @@
                 <editor ref="#JP">Jonathan Prag</editor>
                 <principal ref="#JP">Jonathan Prag</principal>
                 <funder>John Fell OUP Research Fund</funder>
-	   <funder><ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref></funder>
+                <funder>
+                    <ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref>
+                </funder>
                 <respStmt>
                     <name xml:id="JP" ref="http://orcid.org/0000-0003-3819-8537">Jonathan Prag</name>
                     <resp>original data collection and editing</resp>
@@ -34,11 +36,11 @@
                     <name xml:id="TA" ref="https://orcid.org/0000-0001-8417-7089">Tuuli Ahlholm</name>
                     <resp>EpiDoc editing</resp>
                 </respStmt>
-	    <respStmt>
-     	       <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
-     	       <resp>standardisation of template and tidying up encoding</resp>
- 	   </respStmt>
-	    <respStmt>
+                <respStmt>
+                    <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
+                    <resp>standardisation of template and tidying up encoding</resp>
+                </respStmt>
+                <respStmt>
                     <name xml:id="system">system</name>
                     <resp>automated or batch processes</resp>
                 </respStmt>
@@ -82,23 +84,25 @@
                             <supportDesc>
                                 <support>
                                     <material ana="#material.stone.limestone" ref="http://www.eagle-network.eu/voc/material/lod/66.html">limestone</material>
-                                    <dimensions><!--Default values and requires editing-->
+                                    <dimensions>
+                                        <!--Default values and requires editing-->
                                         <height unit="cm"/>
                                         <width unit="cm"/>
                                         <depth unit="cm"/>
                                     </dimensions>
                                 </support>
                                 <condition/>
-		    </supportDesc>
+                            </supportDesc>
                             <layoutDesc>
                                 <layout>
                                     <rs ana="#execution.chiselled" ref="http://www.eagle-network.eu/voc/writing/lod/1">chiselled</rs>
-                                	<damage/>
-			</layout>
+                                    <damage/>
+                                </layout>
                             </layoutDesc>
                         </objectDesc>
                         <handDesc>
-                            <handNote><!--Default value and requires editing-->
+                            <handNote>
+                                <!--Default value and requires editing-->
                                 <locus from="line1" to="line1">Line 1</locus>
                                 <dimensions type="letterHeight">
                                     <height unit="mm"/>
@@ -113,10 +117,10 @@
                     <history>
                         <origin>
                             <origPlace>
-                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462513">Thermae Himeraeae</placeName>		
+                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462513">Thermae Himeraeae</placeName>
                                 <placeName type="modern" ref="http://sws.geonames.org/6539140">Termini Imerese</placeName>
-                            	<geo>37.98365, 13.69555</geo>
-		</origPlace>
+                                <geo>37.98365, 13.69555</geo>
+                            </origPlace>
                             <origDate datingMethod="#julian" notBefore-custom="0001" notAfter-custom="0300" cert="low">Imperial</origDate>
                         </origin>
                         <provenance type="found">Original discovery not recorded.</provenance>
@@ -127,18 +131,18 @@
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
-             <p>Encoded following the latest EpiDoc guidelines</p>
-             <xi:include href="../alists/ISicily-taxonomies.xml">
-                 <xi:fallback>
-                     <p>Taxonomies for ISicily controlled values</p>
-                 </xi:fallback>
-             </xi:include>
-	  <xi:include href="../alists/charDecl.xml">
-	     <xi:fallback>
-	       <p>ISicily glyphs authority list</p>
-	     </xi:fallback>
-	   </xi:include>
-         </encodingDesc>
+            <p>Encoded following the latest EpiDoc guidelines</p>
+            <xi:include href="../alists/ISicily-taxonomies.xml">
+                <xi:fallback>
+                    <p>Taxonomies for ISicily controlled values</p>
+                </xi:fallback>
+            </xi:include>
+            <xi:include href="../alists/charDecl.xml">
+                <xi:fallback>
+                    <p>ISicily glyphs authority list</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
             <calendarDesc>
                 <calendar xml:id="julian">
@@ -168,13 +172,13 @@
             <listChange>
                 <change when="2016-12-03" who="#JCu">James Cummings autogenerated EpiDoc output from database</change>
                 <change when="2018-05-11" who="#TA">Tuuli Ahlholm cleaned up the autogenerated text and added an apparatus</change>
-            	   <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
-            	   <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
-            	<change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
-		<change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
-	    <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
-            	<change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
-	</listChange>
+                <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
+                <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
+                <change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
+                <change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
+                <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
+                <change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
+            </listChange>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -185,31 +189,53 @@
             <graphic n="print" url="ISic000059.jpg" height="3680px" width="5520px">
                 <desc>I.Sicily with the permission of the Assessorato Regionale dei Beni Culturali e dell’Identità Siciliana - Dipartimento dei Beni Culturali e dell’Identità Siciliana</desc>
             </graphic>
-         </surface>
+        </surface>
     </facsimile>
     <text>
         <body>
             <div type="edition" xml:space="preserve" xml:lang="la">
                 <ab>
-                    <lb n="1"/>Publicia <g ref="#interpunct">·</g> Agathia
-                    <lb n="2"/>have
-                    <lb n="3"/>Publicius <g ref="#interpunct">·</g> Brutanus
-                    <lb n="4"/><expan><abbr>d</abbr><ex>e</ex></expan> <expan><abbr>s</abbr><ex>uo</ex></expan> <expan><abbr>f</abbr><ex>ecit</ex></expan>
+                    <lb n="1"/><w n="5">Publicia</w> <g ref="#interpunct">·</g> <w n="10">Agathia</w>
+                    <lb n="2"/><w n="15">have</w>
+                    <lb n="3"/><w n="20">Publicius</w> <g ref="#interpunct">·</g> <w n="25">Brutanus</w>
+                    <lb n="4"/><w n="30"><expan><abbr>d</abbr><ex>e</ex></expan></w> <w n="35"><expan><abbr>s</abbr><ex>uo</ex></expan></w> <w n="40"><expan><abbr>f</abbr><ex>ecit</ex></expan></w>
+                </ab>
+            </div>
+            <div type="edition" subtype="simple-lemmatized">
+                <ab>
+                    <w n="5" lemma="Publicia">Publicia</w>
+                    <w n="10" lemma="Agathia">Agathia</w>
+                    <w n="15" lemma="aveo">have</w>
+                    <w n="20" lemma="Publicius">Publicius</w>
+                    <w n="25" lemma="Brutanus">Brutanus</w>
+                    <w n="30" lemma="de">de</w>
+                    <w n="35" lemma="suus">suo</w>
+                    <w n="40" lemma="facio">fecit</w>
                 </ab>
             </div>
             <div type="apparatus">
                 <listApp>
-                    <app><note>Text of ILTermini</note></app>
-                    <app loc="2"><note>omitted by Fazello</note></app>
-                    <app loc="4"><note>Fazello: D.S.P.</note></app>
+                    <app>
+                        <note>Text of ILTermini</note>
+                    </app>
+                    <app loc="2">
+                        <note>omitted by Fazello</note>
+                    </app>
+                    <app loc="4">
+                        <note>Fazello: D.S.P.</note>
+                    </app>
                 </listApp>
             </div>
             <div type="translation">
-                <p><!--translation(s) - add @xml:lang for 'en' or 'it' to div--></p>
+                <p>
+                    <!--translation(s) - add @xml:lang for 'en' or 'it' to div-->
+                </p>
             </div>
             <div type="commentary">
-                <p><!--commented out pending revision-->
-                    <!--Publicia Agathia have Publicius Brutanus d.s.f. - Agathia an unknown otherwise form of Agathea?; Brutanus also unique; note use of formula ad fin.--></p>
+                <p>
+                    <!--commented out pending revision-->
+                    <!--Publicia Agathia have Publicius Brutanus d.s.f. - Agathia an unknown otherwise form of Agathea?; Brutanus also unique; note use of formula ad fin.-->
+                </p>
             </div>
             <div type="bibliography">
                 <listBibl type="edition">
@@ -253,18 +279,23 @@
                             <ref target="http://arachne.uni-koeln.de/item/buchseite/650799">10.7432</ref>
                         </citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/GQN8UZSI"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10000589">https://biblio.inscriptiones.org/epig10000589</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10000589">https://biblio.inscriptiones.org/epig10000589</ref>
+                    </bibl>
                     <bibl type="corpus" n="ILMusPalermo">
                         <citedRange>60</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/FZWWPUD6"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002142">https://biblio.inscriptiones.org/epig10002142</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10002142">https://biblio.inscriptiones.org/epig10002142</ref>
+                    </bibl>
                     <bibl type="corpus" n="ILMusTermini">
                         <citedRange>135</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/JCV85C79"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002137">https://biblio.inscriptiones.org/epig10002137</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10002137">https://biblio.inscriptiones.org/epig10002137</ref>
+                    </bibl>
                     <bibl/>
                 </listBibl>
-	   <listBibl type="discussion"><bibl/></listBibl>
+                <listBibl type="discussion">
+                    <bibl/>
+                </listBibl>
             </div>
         </body>
     </text>

--- a/inscriptions/ISic000060.xml
+++ b/inscriptions/ISic000060.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../schematron/ircyr-checking.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">
@@ -9,7 +9,9 @@
                 <editor ref="#JP">Jonathan Prag</editor>
                 <principal ref="#JP">Jonathan Prag</principal>
                 <funder>John Fell OUP Research Fund</funder>
-	   <funder><ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref></funder>
+                <funder>
+                    <ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref>
+                </funder>
                 <respStmt>
                     <name xml:id="JP" ref="http://orcid.org/0000-0003-3819-8537">Jonathan Prag</name>
                     <resp>original data collection and editing</resp>
@@ -34,11 +36,11 @@
                     <name xml:id="TA" ref="https://orcid.org/0000-0001-8417-7089">Tuuli Ahlholm</name>
                     <resp>EpiDoc editing</resp>
                 </respStmt>
-	    <respStmt>
-     	       <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
-     	       <resp>standardisation of template and tidying up encoding</resp>
- 	   </respStmt>
-	    <respStmt>
+                <respStmt>
+                    <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
+                    <resp>standardisation of template and tidying up encoding</resp>
+                </respStmt>
+                <respStmt>
                     <name xml:id="system">system</name>
                     <resp>automated or batch processes</resp>
                 </respStmt>
@@ -83,23 +85,25 @@
                             <supportDesc>
                                 <support>
                                     <material ana="#material.stone.marble" ref="http://www.eagle-network.eu/voc/material/lod/48.html">marble</material>
-                                    <dimensions><!--Default values and requires editing-->
+                                    <dimensions>
+                                        <!--Default values and requires editing-->
                                         <height unit="cm"/>
                                         <width unit="cm"/>
                                         <depth unit="cm"/>
                                     </dimensions>
                                 </support>
                                 <condition/>
-		    </supportDesc>
+                            </supportDesc>
                             <layoutDesc>
                                 <layout>
                                     <rs ana="#execution.chiselled" ref="http://www.eagle-network.eu/voc/writing/lod/1">chiselled</rs>
-                                	<damage/>
-			</layout>
+                                    <damage/>
+                                </layout>
                             </layoutDesc>
                         </objectDesc>
                         <handDesc>
-                            <handNote><!--Default value and requires editing-->
+                            <handNote>
+                                <!--Default value and requires editing-->
                                 <locus from="line1" to="line1">Line 1</locus>
                                 <dimensions type="letterHeight">
                                     <height unit="mm"/>
@@ -114,10 +118,10 @@
                     <history>
                         <origin>
                             <origPlace>
-                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462513" cert="low">Thermae Himeraeae</placeName>		
+                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462513" cert="low">Thermae Himeraeae</placeName>
                                 <placeName type="modern" ref="http://sws.geonames.org/6539140">Termini Imerese</placeName>
-                            	<geo>37.98365, 13.69555</geo>
-		</origPlace>
+                                <geo>37.98365, 13.69555</geo>
+                            </origPlace>
                             <origDate datingMethod="#julian" notBefore-custom="0100" notAfter-custom="0200" cert="low">Caratteri
                                 allungati e assai eleganti del II s.d.C.</origDate>
                         </origin>
@@ -129,18 +133,18 @@
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
-             <p>Encoded following the latest EpiDoc guidelines</p>
-             <xi:include href="../alists/ISicily-taxonomies.xml">
-                 <xi:fallback>
-                     <p>Taxonomies for ISicily controlled values</p>
-                 </xi:fallback>
-             </xi:include>
-	  <xi:include href="../alists/charDecl.xml">
-	     <xi:fallback>
-	       <p>ISicily glyphs authority list</p>
-	     </xi:fallback>
-	   </xi:include>
-         </encodingDesc>
+            <p>Encoded following the latest EpiDoc guidelines</p>
+            <xi:include href="../alists/ISicily-taxonomies.xml">
+                <xi:fallback>
+                    <p>Taxonomies for ISicily controlled values</p>
+                </xi:fallback>
+            </xi:include>
+            <xi:include href="../alists/charDecl.xml">
+                <xi:fallback>
+                    <p>ISicily glyphs authority list</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
             <calendarDesc>
                 <calendar xml:id="julian">
@@ -170,13 +174,13 @@
             <listChange>
                 <change when="2016-12-03" who="#JCu">James Cummings autogenerated EpiDoc output from database</change>
                 <change when="2018-05-11" who="#TA">Tuuli Ahlholm cleaned up the autogenerated text and added an apparatus</change>
-            	   <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
-            	   <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
-            	<change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
-		<change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
-	    <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
-            	<change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
-	</listChange>
+                <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
+                <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
+                <change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
+                <change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
+                <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
+                <change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
+            </listChange>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -187,26 +191,39 @@
             <graphic n="print" url="ISic000060.jpg" height="3680px" width="5520px">
                 <desc>I.Sicily with the permission of the Assessorato Regionale dei Beni Culturali e dell’Identità Siciliana - Dipartimento dei Beni Culturali e dell’Identità Siciliana</desc>
             </graphic>
-         </surface>
+        </surface>
     </facsimile>
     <text>
         <body>
             <div type="edition" xml:space="preserve" xml:lang="la">
                 <ab>
-                    <lb n="1"/><gap reason="lost" extent="unknown" unit="character"/>nia <g ref="#interpunct">·</g> <expan><abbr>Secund</abbr><ex>a</ex></expan> <g ref="#interpunct">·</g>
+                    <lb n="1"/><gap reason="lost" extent="unknown" unit="character"/><w n="5">nia</w> <g ref="#interpunct">·</g> <w n="10"><expan><abbr>Secund</abbr><ex>a</ex></expan></w> <g ref="#interpunct">·</g>
+                </ab>
+            </div>
+            <div type="edition" subtype="simple-lemmatized">
+                <ab>
+                    <gap reason="lost" extent="unknown" unit="character"/>
+                    <w n="5" lemma="NOLEMMA">nia</w>
+                    <w n="10" lemma="Secunda">Secunda</w>
                 </ab>
             </div>
             <div type="apparatus">
                 <listApp>
-                    <app><note>Text of ILTermini</note></app>
+                    <app>
+                        <note>Text of ILTermini</note>
+                    </app>
                 </listApp>
             </div>
             <div type="translation">
-                <p><!--translation(s) - add @xml:lang for 'en' or 'it' to div--></p>
+                <p>
+                    <!--translation(s) - add @xml:lang for 'en' or 'it' to div-->
+                </p>
             </div>
             <div type="commentary">
-                <p><!--commented out pending revision-->
-                    <!--- - -nia Secund(a)--></p>
+                <p>
+                    <!--commented out pending revision-->
+                    <!--- - -nia Secund(a)-->
+                </p>
             </div>
             <div type="bibliography">
                 <listBibl type="edition">
@@ -215,18 +232,23 @@
                             <ref target="http://arachne.uni-koeln.de/item/buchseite/650800">10.7436</ref>
                         </citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/GQN8UZSI"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10000589">https://biblio.inscriptiones.org/epig10000589</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10000589">https://biblio.inscriptiones.org/epig10000589</ref>
+                    </bibl>
                     <bibl type="corpus" n="ILMusPalermo">
                         <citedRange>61</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/FZWWPUD6"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002142">https://biblio.inscriptiones.org/epig10002142</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10002142">https://biblio.inscriptiones.org/epig10002142</ref>
+                    </bibl>
                     <bibl type="corpus" n="ILMusTermini">
                         <citedRange>142</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/JCV85C79"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002137">https://biblio.inscriptiones.org/epig10002137</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10002137">https://biblio.inscriptiones.org/epig10002137</ref>
+                    </bibl>
                     <bibl/>
                 </listBibl>
-	   <listBibl type="discussion"><bibl/></listBibl>
+                <listBibl type="discussion">
+                    <bibl/>
+                </listBibl>
             </div>
         </body>
     </text>

--- a/inscriptions/ISic000061.xml
+++ b/inscriptions/ISic000061.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../schematron/ircyr-checking.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">
@@ -9,7 +9,9 @@
                 <editor ref="#JP">Jonathan Prag</editor>
                 <principal ref="#JP">Jonathan Prag</principal>
                 <funder>John Fell OUP Research Fund</funder>
-	   <funder><ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref></funder>
+                <funder>
+                    <ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref>
+                </funder>
                 <respStmt>
                     <name xml:id="JP" ref="http://orcid.org/0000-0003-3819-8537">Jonathan Prag</name>
                     <resp>original data collection and editing</resp>
@@ -34,11 +36,11 @@
                     <name xml:id="TA" ref="https://orcid.org/0000-0001-8417-7089">Tuuli Ahlholm</name>
                     <resp>EpiDoc editing</resp>
                 </respStmt>
-	    <respStmt>
-     	       <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
-     	       <resp>standardisation of template and tidying up encoding</resp>
- 	   </respStmt>
-	    <respStmt>
+                <respStmt>
+                    <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
+                    <resp>standardisation of template and tidying up encoding</resp>
+                </respStmt>
+                <respStmt>
                     <name xml:id="system">system</name>
                     <resp>automated or batch processes</resp>
                 </respStmt>
@@ -83,23 +85,26 @@
                             <supportDesc>
                                 <support>
                                     <material ana="#material.stone.marble" ref="http://www.eagle-network.eu/voc/material/lod/48.html">marble</material>
-                                    <dimensions><!--Default values and requires editing-->
+                                    <dimensions>
+                                        <!--Default values and requires editing-->
                                         <height unit="cm"/>
                                         <width unit="cm"/>
                                         <depth unit="cm"/>
                                     </dimensions>
                                 </support>
                                 <condition/>
-		    </supportDesc>
+                            </supportDesc>
                             <layoutDesc>
-                                <layout><!--Default value and requires checking-->
+                                <layout>
+                                    <!--Default value and requires checking-->
                                     <rs ana="#execution.chiselled" ref="http://www.eagle-network.eu/voc/writing/lod/1">chiselled</rs>
-                                	<damage/>
-			</layout>
+                                    <damage/>
+                                </layout>
                             </layoutDesc>
                         </objectDesc>
                         <handDesc>
-                            <handNote><!--Default value and requires editing-->
+                            <handNote>
+                                <!--Default value and requires editing-->
                                 <locus from="line1" to="line1">Line 1</locus>
                                 <dimensions type="letterHeight">
                                     <height unit="mm"/>
@@ -114,10 +119,10 @@
                     <history>
                         <origin>
                             <origPlace>
-                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462513">Thermae Himeraeae</placeName>		
+                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462513">Thermae Himeraeae</placeName>
                                 <placeName type="modern" ref="http://sws.geonames.org/6539140">Termini Imerese</placeName>
-                            	<geo>37.98365, 13.69555</geo>
-		</origPlace>
+                                <geo>37.98365, 13.69555</geo>
+                            </origPlace>
                             <origDate datingMethod="#julian" notBefore-custom="0201" notAfter-custom="0300" precision="low">3rd century CE</origDate>
                         </origin>
                         <provenance type="found">Original discovery not recorded.</provenance>
@@ -128,18 +133,18 @@
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
-             <p>Encoded following the latest EpiDoc guidelines</p>
-             <xi:include href="../alists/ISicily-taxonomies.xml">
-                 <xi:fallback>
-                     <p>Taxonomies for ISicily controlled values</p>
-                 </xi:fallback>
-             </xi:include>
-	  <xi:include href="../alists/charDecl.xml">
-	     <xi:fallback>
-	       <p>ISicily glyphs authority list</p>
-	     </xi:fallback>
-	   </xi:include>
-         </encodingDesc>
+            <p>Encoded following the latest EpiDoc guidelines</p>
+            <xi:include href="../alists/ISicily-taxonomies.xml">
+                <xi:fallback>
+                    <p>Taxonomies for ISicily controlled values</p>
+                </xi:fallback>
+            </xi:include>
+            <xi:include href="../alists/charDecl.xml">
+                <xi:fallback>
+                    <p>ISicily glyphs authority list</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
             <calendarDesc>
                 <calendar xml:id="julian">
@@ -169,13 +174,13 @@
             <listChange>
                 <change when="2016-12-03" who="#JCu">James Cummings autogenerated EpiDoc output from database</change>
                 <change when="2018-05-11" who="#TA">Tuuli Ahlholm cleaned up the autogenerated text and added an apparatus</change>
-            	   <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
-            	   <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
-            	<change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
-		<change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
-	    <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
-            	<change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
-	</listChange>
+                <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
+                <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
+                <change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
+                <change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
+                <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
+                <change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
+            </listChange>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -186,31 +191,57 @@
             <graphic n="print" url="ISic000061.jpg" height="3680px" width="5520px">
                 <desc>I.Sicily with the permission of the Assessorato Regionale dei Beni Culturali e dell’Identità Siciliana - Dipartimento dei Beni Culturali e dell’Identità Siciliana</desc>
             </graphic>
-         </surface>
+        </surface>
     </facsimile>
     <text>
         <body>
             <div type="edition" xml:space="preserve" xml:lang="la">
                 <ab>
-                    <lb n="1"/><gap reason="lost" quantity="1" unit="line"/> 
-                    <lb n="2"/><expan><abbr>D</abbr><ex>ecimus</ex></expan> <g ref="#interpunct">·</g> Vi<unclear>b</unclear><gap reason="lost" extent="unknown" unit="character"/>i
-                    <lb n="3"/>vix<unclear>i</unclear><supplied reason="lost">t</supplied>
-                    <lb n="4"/>annos <gap reason="lost" extent="unknown" unit="character"/> <g ref="#interpunct">·</g> <gap reason="lost" extent="unknown" unit="character"/><num value="33">X<supplied reason="lost">X</supplied>XIII</num>
+                    <lb n="1"/><gap reason="lost" quantity="1" unit="line"/>
+                    <lb n="2"/><w n="5"><expan><abbr>D</abbr><ex>ecimus</ex></expan></w> <g ref="#interpunct">·</g> <w n="10">Vi<unclear>b</unclear></w> <gap reason="lost" extent="unknown" unit="character"/><w n="15">i</w>
+                    <lb n="3"/><w n="20">vix<unclear>i</unclear><supplied reason="lost">t</supplied></w>
+                    <lb n="4"/><w n="25">annos</w> <gap reason="lost" extent="unknown" unit="character"/><g ref="#interpunct">·</g> <gap reason="lost" extent="unknown" unit="character"/><num value="33"><w n="30">X<supplied reason="lost">X</supplied>XIII</w></num>
+                </ab>
+            </div>
+            <div type="edition" subtype="simple-lemmatized">
+                <ab>
+                    <gap reason="lost" quantity="1" unit="line"/>
+                    <w n="5" lemma="Decimus">Decimus</w>
+                    <w n="10" lemma="NOLEMMA">Vib</w>
+                    <gap reason="lost" extent="unknown" unit="character"/>
+                    <w n="15" lemma="NOLEMMA">i</w>
+                    <w n="20" lemma="vivo">vixit</w>
+                    <w n="25" lemma="annus">annos</w>
+                    <gap reason="lost" extent="unknown" unit="character"/>
+                    <gap reason="lost" extent="unknown" unit="character"/>
+                    <w n="30" lemma="XXXIII">XXXIII</w>
                 </ab>
             </div>
             <div type="apparatus">
                 <listApp>
-                    <app><note>Text of ILTermini</note></app>
-                    <app loc="line 1"><note>Some strokes of the last letter survive and suggest it could be 'A' or 'X'</note></app>
-                    <app loc="line 2"><note>Mommsen reads <hi rend="italic">D. Vibl[---]</hi></note></app>
+                    <app>
+                        <note>Text of ILTermini</note>
+                    </app>
+                    <app loc="line 1">
+                        <note>Some strokes of the last letter survive and suggest it could be 'A' or 'X'</note>
+                    </app>
+                    <app loc="line 2">
+                        <note>
+                            Mommsen reads<hi rend="italic">D. Vibl[---]</hi>
+                        </note>
+                    </app>
                 </listApp>
             </div>
             <div type="translation">
-                <p><!--translation(s) - add @xml:lang for 'en' or 'it' to div--></p>
+                <p>
+                    <!--translation(s) - add @xml:lang for 'en' or 'it' to div-->
+                </p>
             </div>
             <div type="commentary">
-                <p><!--commented out pending revision-->
-                    <!--v frag.--></p>
+                <p>
+                    <!--commented out pending revision-->
+                    <!--v frag.-->
+                </p>
             </div>
             <div type="bibliography">
                 <listBibl type="edition">
@@ -219,18 +250,23 @@
                             <ref target="http://arachne.uni-koeln.de/item/buchseite/650801">10.7446</ref>
                         </citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/GQN8UZSI"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10000589">https://biblio.inscriptiones.org/epig10000589</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10000589">https://biblio.inscriptiones.org/epig10000589</ref>
+                    </bibl>
                     <bibl type="corpus" n="ILMusPalermo">
                         <citedRange>62</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/FZWWPUD6"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002142">https://biblio.inscriptiones.org/epig10002142</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10002142">https://biblio.inscriptiones.org/epig10002142</ref>
+                    </bibl>
                     <bibl type="corpus" n="ILMusTermini">
                         <citedRange>158</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/JCV85C79"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002137">https://biblio.inscriptiones.org/epig10002137</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10002137">https://biblio.inscriptiones.org/epig10002137</ref>
+                    </bibl>
                     <bibl/>
                 </listBibl>
-	   <listBibl type="discussion"><bibl/></listBibl>
+                <listBibl type="discussion">
+                    <bibl/>
+                </listBibl>
             </div>
         </body>
     </text>

--- a/inscriptions/ISic000062.xml
+++ b/inscriptions/ISic000062.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../schematron/ircyr-checking.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">
@@ -9,7 +9,9 @@
                 <editor ref="#JP">Jonathan Prag</editor>
                 <principal ref="#JP">Jonathan Prag</principal>
                 <funder>John Fell OUP Research Fund</funder>
-	   <funder><ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref></funder>
+                <funder>
+                    <ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref>
+                </funder>
                 <respStmt>
                     <name xml:id="JP" ref="http://orcid.org/0000-0003-3819-8537">Jonathan Prag</name>
                     <resp>original data collection and editing</resp>
@@ -34,11 +36,11 @@
                     <name xml:id="TA" ref="https://orcid.org/0000-0001-8417-7089">Tuuli Ahlholm</name>
                     <resp>EpiDoc editing</resp>
                 </respStmt>
-	    <respStmt>
-     	       <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
-     	       <resp>standardisation of template and tidying up encoding</resp>
- 	   </respStmt>
-	    <respStmt>
+                <respStmt>
+                    <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
+                    <resp>standardisation of template and tidying up encoding</resp>
+                </respStmt>
+                <respStmt>
                     <name xml:id="system">system</name>
                     <resp>automated or batch processes</resp>
                 </respStmt>
@@ -83,23 +85,25 @@
                             <supportDesc>
                                 <support>
                                     <material ana="#material.stone.limestone" ref="http://www.eagle-network.eu/voc/material/lod/66.html">limestone</material>
-                                    <dimensions><!--Default values and requires editing-->
+                                    <dimensions>
+                                        <!--Default values and requires editing-->
                                         <height unit="cm"/>
                                         <width unit="cm"/>
                                         <depth unit="cm"/>
                                     </dimensions>
                                 </support>
                                 <condition/>
-		    </supportDesc>
+                            </supportDesc>
                             <layoutDesc>
                                 <layout>
                                     <rs ana="#execution.chiselled" ref="http://www.eagle-network.eu/voc/writing/lod/1">chiselled</rs>
-                                	<damage/>
-			</layout>
+                                    <damage/>
+                                </layout>
                             </layoutDesc>
                         </objectDesc>
                         <handDesc>
-                            <handNote><!--Default value and requires editing-->
+                            <handNote>
+                                <!--Default value and requires editing-->
                                 <locus from="line1" to="line1">Line 1</locus>
                                 <dimensions type="letterHeight">
                                     <height unit="mm"/>
@@ -114,10 +118,10 @@
                     <history>
                         <origin>
                             <origPlace>
-                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462513">Thermae Himeraeae</placeName>		
+                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462513">Thermae Himeraeae</placeName>
                                 <placeName type="modern" ref="http://sws.geonames.org/6539140">Termini Imerese</placeName>
-                            	<geo>37.98365, 13.69555</geo>
-		</origPlace>
+                                <geo>37.98365, 13.69555</geo>
+                            </origPlace>
                             <origDate datingMethod="#julian" notBefore-custom="0200" notAfter-custom="0400" cert="low">post-Marcus
                                 Aurelius</origDate>
                         </origin>
@@ -129,18 +133,18 @@
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
-             <p>Encoded following the latest EpiDoc guidelines</p>
-             <xi:include href="../alists/ISicily-taxonomies.xml">
-                 <xi:fallback>
-                     <p>Taxonomies for ISicily controlled values</p>
-                 </xi:fallback>
-             </xi:include>
-	  <xi:include href="../alists/charDecl.xml">
-	     <xi:fallback>
-	       <p>ISicily glyphs authority list</p>
-	     </xi:fallback>
-	   </xi:include>
-         </encodingDesc>
+            <p>Encoded following the latest EpiDoc guidelines</p>
+            <xi:include href="../alists/ISicily-taxonomies.xml">
+                <xi:fallback>
+                    <p>Taxonomies for ISicily controlled values</p>
+                </xi:fallback>
+            </xi:include>
+            <xi:include href="../alists/charDecl.xml">
+                <xi:fallback>
+                    <p>ISicily glyphs authority list</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
             <calendarDesc>
                 <calendar xml:id="julian">
@@ -170,13 +174,13 @@
             <listChange>
                 <change when="2016-12-03" who="#JCu">James Cummings autogenerated EpiDoc output from database</change>
                 <change when="2018-05-11" who="#TA">Tuuli Ahlholm cleaned up the autogenerated text and added an apparatus</change>
-            	   <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
-            	   <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
-            	<change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
-		<change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
-	    <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
-            	<change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
-	</listChange>
+                <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
+                <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
+                <change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
+                <change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
+                <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
+                <change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
+            </listChange>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -187,28 +191,46 @@
             <graphic n="print" url="ISic000062.jpg" height="3680px" width="5520px">
                 <desc>I.Sicily with the permission of the Assessorato Regionale dei Beni Culturali e dell’Identità Siciliana - Dipartimento dei Beni Culturali e dell’Identità Siciliana</desc>
             </graphic>
-         </surface>
+        </surface>
     </facsimile>
     <text>
         <body>
             <div type="edition" xml:space="preserve" xml:lang="la">
                 <ab>
-                    <lb n="1"/><expan><abbr>L</abbr><ex>ucius</ex></expan> <g ref="#interpunct">·</g> Volumniu<unclear>s</unclear>
-                    <lb n="2"/>Parsianus
-                    <lb n="3"/><expan><abbr>vix</abbr><ex>it</ex></expan> <g ref="#interpunct">·</g> <expan><abbr>an</abbr><ex>nis</ex></expan> <g ref="#interpunct">·</g> <num value="13">XIII</num> <expan><abbr>m</abbr><ex>ensibus</ex></expan> <num value="4">IV</num>
+                    <lb n="1"/><w n="5"><expan><abbr>L</abbr><ex>ucius</ex></expan></w> <g ref="#interpunct">·</g> <w n="10">Volumniu<unclear>s</unclear></w>
+                    <lb n="2"/><w n="15">Parsianus</w>
+                    <lb n="3"/><w n="20"><expan><abbr>vix</abbr><ex>it</ex></expan></w> <g ref="#interpunct">·</g> <w n="25"><expan><abbr>an</abbr><ex>nis</ex></expan></w> <g ref="#interpunct">·</g> <num value="13"><w n="30">XIII</w></num> <w n="35"><expan><abbr>m</abbr><ex>ensibus</ex></expan></w> <num value="4"><w n="40">IV</w></num>
+                </ab>
+            </div>
+            <div type="edition" subtype="simple-lemmatized">
+                <ab>
+                    <w n="5" lemma="Lucius">Lucius</w>
+                    <w n="10" lemma="Volumnius">Volumnius</w>
+                    <w n="15" lemma="Parsianus">Parsianus</w>
+                    <w n="20" lemma="vivo">vixit</w>
+                    <w n="25" lemma="annus">annis</w>
+                    <w n="30" lemma="XIII">XIII</w>
+                    <w n="35" lemma="mensis">mensibus</w>
+                    <w n="40" lemma="IV">IV</w>
                 </ab>
             </div>
             <div type="apparatus">
                 <listApp>
-                    <app><note>Text of ILTermini</note></app>
+                    <app>
+                        <note>Text of ILTermini</note>
+                    </app>
                 </listApp>
             </div>
             <div type="translation">
-                <p><!--translation(s) - add @xml:lang for 'en' or 'it' to div--></p>
+                <p>
+                    <!--translation(s) - add @xml:lang for 'en' or 'it' to div-->
+                </p>
             </div>
             <div type="commentary">
-                <p><!--commented out pending revision-->
-                    <!--L.Volumnius Parsianus - cognom. is v.rare; cf. gens Parria at Tarquinia?--></p>
+                <p>
+                    <!--commented out pending revision-->
+                    <!--L.Volumnius Parsianus - cognom. is v.rare; cf. gens Parria at Tarquinia?-->
+                </p>
             </div>
             <div type="bibliography">
                 <listBibl type="edition">
@@ -217,18 +239,23 @@
                             <ref target="http://arachne.uni-koeln.de/item/buchseite/650801">10.7447</ref>
                         </citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/GQN8UZSI"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10000589">https://biblio.inscriptiones.org/epig10000589</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10000589">https://biblio.inscriptiones.org/epig10000589</ref>
+                    </bibl>
                     <bibl type="corpus" n="ILMusPalermo">
                         <citedRange>63</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/FZWWPUD6"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002142">https://biblio.inscriptiones.org/epig10002142</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10002142">https://biblio.inscriptiones.org/epig10002142</ref>
+                    </bibl>
                     <bibl type="corpus" n="ILMusTermini">
                         <citedRange>161</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/JCV85C79"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002137">https://biblio.inscriptiones.org/epig10002137</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10002137">https://biblio.inscriptiones.org/epig10002137</ref>
+                    </bibl>
                     <bibl/>
                 </listBibl>
-	   <listBibl type="discussion"><bibl/></listBibl>
+                <listBibl type="discussion">
+                    <bibl/>
+                </listBibl>
             </div>
         </body>
     </text>

--- a/inscriptions/ISic000092.xml
+++ b/inscriptions/ISic000092.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../schematron/ircyr-checking.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">
@@ -9,7 +9,9 @@
                 <editor ref="#JP">Jonathan Prag</editor>
                 <principal ref="#JP">Jonathan Prag</principal>
                 <funder>John Fell OUP Research Fund</funder>
-	   <funder><ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref></funder>
+                <funder>
+                    <ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref>
+                </funder>
                 <respStmt>
                     <name xml:id="JP" ref="http://orcid.org/0000-0003-3819-8537">Jonathan Prag</name>
                     <resp>original data collection and editing</resp>
@@ -34,11 +36,11 @@
                     <name xml:id="TA" ref="https://orcid.org/0000-0001-8417-7089">Tuuli Ahlholm</name>
                     <resp>EpiDoc editing</resp>
                 </respStmt>
-	    <respStmt>
-     	       <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
-     	       <resp>standardisation of template and tidying up encoding</resp>
- 	   </respStmt>
-	    <respStmt>
+                <respStmt>
+                    <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
+                    <resp>standardisation of template and tidying up encoding</resp>
+                </respStmt>
+                <respStmt>
                     <name xml:id="system">system</name>
                     <resp>automated or batch processes</resp>
                 </respStmt>
@@ -78,7 +80,8 @@
                     <physDesc>
                         <objectDesc>
                             <supportDesc>
-                                <support><p>Large limestone slab, seemingly intact above and to the sides, but missing the lower left and right corners. Rough behind, thicker in the centre, reduced on all edges behind, as if for insertion into a wall or monument. Edges are picked rather than finished, but the face is smooth.</p>
+                                <support>
+                                    <p>Large limestone slab, seemingly intact above and to the sides, but missing the lower left and right corners. Rough behind, thicker in the centre, reduced on all edges behind, as if for insertion into a wall or monument. Edges are picked rather than finished, but the face is smooth.</p>
                                     <material ana="#material.stone.limestone" ref="http://www.eagle-network.eu/voc/material/lod/66.html">limestone</material>
                                     <objectType ana="#object.plaque" ref="http://www.eagle-network.eu/voc/objtyp/lod/259">plaque</objectType>
                                     <dimensions>
@@ -88,16 +91,18 @@
                                     </dimensions>
                                 </support>
                                 <condition/>
-		    </supportDesc>
+                            </supportDesc>
                             <layoutDesc>
-                                <layout><p>Six lines of large Latin letters which reduce in height, with a vacat below.</p>
+                                <layout>
+                                    <p>Six lines of large Latin letters which reduce in height, with a vacat below.</p>
                                     <rs ana="#execution.chiselled" ref="http://www.eagle-network.eu/voc/writing/lod/1">chiselled</rs>
-                                	<damage/>
-			</layout>
+                                    <damage/>
+                                </layout>
                             </layoutDesc>
                         </objectDesc>
                         <handDesc>
-                            <handNote><p>Fine monumental letters with occasional serif flourishes, and some taller letters. Lightly incised hederae for interpuncts.</p>
+                            <handNote>
+                                <p>Fine monumental letters with occasional serif flourishes, and some taller letters. Lightly incised hederae for interpuncts.</p>
                                 <locus from="line1" to="line1">Line 1</locus>
                                 <dimensions type="letterHeight">
                                     <height unit="mm">83-92</height>
@@ -148,10 +153,10 @@
                     <history>
                         <origin>
                             <origPlace>
-                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462513">Thermae Himeraeae</placeName>		
+                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462513">Thermae Himeraeae</placeName>
                                 <placeName type="modern" ref="http://sws.geonames.org/6539140">Termini Imerese</placeName>
-                            	<geo>37.98365, 13.69555</geo>
-		</origPlace>
+                                <geo>37.98365, 13.69555</geo>
+                            </origPlace>
                             <origDate datingMethod="#julian" notBefore-custom="0240" notAfter-custom="0270" evidence="prosopography">Usually thought either to refer to C.Maesius Titianus, cos. 245 CE, or a likely relative of similar period.</origDate>
                         </origin>
                         <provenance type="found" subtype="discovered" notAfter="1624">Original discovery not recorded, but already recorded by Gualtherus 1624 in the principal church of Termini Imerese, 'in ara plana'.</provenance>
@@ -162,18 +167,18 @@
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
-             <p>Encoded following the latest EpiDoc guidelines</p>
-             <xi:include href="../alists/ISicily-taxonomies.xml">
-                 <xi:fallback>
-                     <p>Taxonomies for ISicily controlled values</p>
-                 </xi:fallback>
-             </xi:include>
-	  <xi:include href="../alists/charDecl.xml">
-	     <xi:fallback>
-	       <p>ISicily glyphs authority list</p>
-	     </xi:fallback>
-	   </xi:include>
-         </encodingDesc>
+            <p>Encoded following the latest EpiDoc guidelines</p>
+            <xi:include href="../alists/ISicily-taxonomies.xml">
+                <xi:fallback>
+                    <p>Taxonomies for ISicily controlled values</p>
+                </xi:fallback>
+            </xi:include>
+            <xi:include href="../alists/charDecl.xml">
+                <xi:fallback>
+                    <p>ISicily glyphs authority list</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
             <calendarDesc>
                 <calendar xml:id="julian">
@@ -204,49 +209,82 @@
                 <change when="2016-12-03" who="#JCu">James Cummings autogenerated EpiDoc output from database</change>
                 <change when="2018-05-18" who="#TA">Tuuli Ahlholm cleaned up the autogenerated text and added an apparatus and translation</change>
                 <change when="2019-02-12" who="#JP">Jonathan Prag added image and bibl</change>
-            	   <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
-            	   <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
-            	<change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
-		<change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
-	    <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
-            	<change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
+                <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
+                <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
+                <change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
+                <change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
+                <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
+                <change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
                 <change when="2024-02-12" who="#JP">Jonathan Prag revised from autopsy notes</change>
-	</listChange>
+            </listChange>
         </revisionDesc>
     </teiHeader>
     <facsimile>
         <surface type="front">
             <graphic n="screen" url="ISic000092_tiled.tif" height="3680px" width="5520px">
                 <desc>Photo J. Prag, courtesy Museo Civico Baldassare Romano</desc>
-             </graphic>
-              <graphic n="print" url="ISic000092.jpg" height="3680px" width="5520px">
-                  <desc>Photo J. Prag, courtesy Museo Civico Baldassare Romano</desc>
-    </graphic>
-  </surface>
+            </graphic>
+            <graphic n="print" url="ISic000092.jpg" height="3680px" width="5520px">
+                <desc>Photo J. Prag, courtesy Museo Civico Baldassare Romano</desc>
+            </graphic>
+        </surface>
     </facsimile>
     <text>
         <body>
             <div type="edition" xml:space="preserve" xml:lang="la" resp="#TA">
                 <ab>
-                    <lb n="1" xml:id="AJUAK"/><persName type="attested" xml:id="AJUAU"><name xml:id="AJUAe"><expan xml:id="AJUAo"><abbr xml:id="AJUAy">C</abbr><ex xml:id="AJUAΙ">aio</ex></expan></name> <g ref="#ivy-leaf" xml:id="AJUAΤ">❦</g> <name xml:id="AJUAε">Maesio</name> <g ref="#ivy-leaf" xml:id="AJUAο">❦</g> <name xml:id="AJUBA">Aquillio</name> 
-                    <lb n="2" xml:id="AJUBK"/><name xml:id="AJUBU">Fabio</name> <name xml:id="AJUBe"><hi rend="tall" xml:id="AJUBo">T</hi>i<hi rend="tall" xml:id="AJUBy">t</hi>iano</name></persName> <g ref="#interpunct" xml:id="AJUBΙ">·</g> <roleName type="supracivic" subtype="clarissimus" xml:id="AJUBΤ"><w xml:id="AJUBε"><expan xml:id="AJUBο"><abbr xml:id="AJUCA">c</abbr><ex xml:id="AJUCK">larissimo</ex></expan></w></roleName> <g ref="#interpunct" xml:id="AJUCU">·</g> <w xml:id="AJUCe"><expan xml:id="AJUCo"><abbr xml:id="AJUCy">v</abbr><ex xml:id="AJUCΙ">iro</ex></expan></w> <g ref="#interpunct" xml:id="AJUCΤ">·</g> <roleName type="supracivic" subtype="consul" xml:id="AJUCε"><w xml:id="AJUCο"><expan xml:id="AJUDA"><abbr xml:id="AJUDK">co</abbr><ex xml:id="AJUDU">n</ex><abbr xml:id="AJUDe"><hi rend="tall" xml:id="AJUDo">s</hi></abbr><ex xml:id="AJUDy">uli</ex></expan></w></roleName> <g ref="#ivy-leaf" xml:id="AJUDΙ">❦</g> 
-                    <lb n="3" xml:id="AJUDΤ"/><w xml:id="AJUDε">optimo</w> <roleName type="civic" subtype="civis" xml:id="AJUDο"><w xml:id="AJUEA">civi</w></roleName> <w xml:id="AJUEK">ac</w> <roleName type="paracivic" subtype="patronus" xml:id="AJUEU"><w xml:id="AJUEe">patrono</w></roleName> <w xml:id="AJUEo">bene</w> <w xml:id="AJUEy">me
-                    <lb n="4" break="no" xml:id="AJUEΙ"/>renti</w> <g ref="#ivy-leaf" xml:id="AJUEΤ">❦</g> <space unit="character" quantity="3" xml:id="AJUEε"/><w xml:id="AJUEο">ordo</w> <w xml:id="AJUFA">et</w> <w xml:id="AJUFK">popu<hi rend="tall" xml:id="AJUFU">l</hi>us</w> <w xml:id="AJUFe">splen
-                    <lb n="5" break="no" xml:id="AJUFo"/><supplied reason="lost" xml:id="AJUFy">d</supplied>idis<hi rend="tall" xml:id="AJUFΙ">s</hi>imae</w> <placeName type="ancient" xml:id="AJUFΤ"><w xml:id="AJUFε"><expan xml:id="AJUFο"><abbr xml:id="AJUGA">col</abbr><ex xml:id="AJUGK">oniae</ex></expan></w> <w xml:id="AJUGU"><expan xml:id="AJUGe"><abbr xml:id="AJUGo">Aug</abbr><ex xml:id="AJUGy">ustae</ex></expan></w> <w xml:id="AJUGΙ">Himereorum</w> 
-                    <lb n="6" xml:id="AJUGΤ"/><w xml:id="AJUGε"><expan xml:id="AJUGο"><abbr xml:id="AJUHA"><supplied reason="lost" xml:id="AJUHK">The</supplied>rmi<hi rend="tall" xml:id="AJUHU">t</hi></abbr><ex xml:id="AJUHe">anorum</ex></expan></w></placeName> <g ref="#ivy-leaf" xml:id="AJUHo">❦</g> <space unit="character" quantity="1" xml:id="AJUHy"/><w xml:id="AJUHΙ">pecunia</w> <w xml:id="AJUHΤ">sua</w> <w xml:id="AJUHε">posui<hi rend="tall" xml:id="AJUHο">t</hi></w>
+                    <lb n="1" xml:id="AJUAK"/><persName type="attested" xml:id="AJUAU"><name xml:id="AJUAe"><w n="5"><expan xml:id="AJUAo"><abbr xml:id="AJUAy">C</abbr><ex xml:id="AJUAΙ">aio</ex></expan></w></name> <g ref="#ivy-leaf" xml:id="AJUAΤ">❦</g> <name xml:id="AJUAε"><w n="10">Maesio</w></name> <g ref="#ivy-leaf" xml:id="AJUAο">❦</g> <name xml:id="AJUBA"><w n="15">Aquillio</w></name>
+                    <lb n="2" xml:id="AJUBK"/><name xml:id="AJUBU"><w n="20">Fabio</w></name> <name xml:id="AJUBe"><w n="25"><hi rend="tall" xml:id="AJUBo">T</hi>i<hi rend="tall" xml:id="AJUBy">t</hi>iano</w></name></persName> <g ref="#interpunct" xml:id="AJUBΙ">·</g> <roleName type="supracivic" subtype="clarissimus" xml:id="AJUBΤ"><w xml:id="AJUBε" n="30"><expan xml:id="AJUBο"><abbr xml:id="AJUCA">c</abbr><ex xml:id="AJUCK">larissimo</ex></expan></w></roleName> <g ref="#interpunct" xml:id="AJUCU">·</g> <w xml:id="AJUCe" n="35"><expan xml:id="AJUCo"><abbr xml:id="AJUCy">v</abbr><ex xml:id="AJUCΙ">iro</ex></expan></w> <g ref="#interpunct" xml:id="AJUCΤ">·</g> <roleName type="supracivic" subtype="consul" xml:id="AJUCε"><w xml:id="AJUCο" n="40"><expan xml:id="AJUDA"><abbr xml:id="AJUDK">co</abbr><ex xml:id="AJUDU">n</ex><abbr xml:id="AJUDe"><hi rend="tall" xml:id="AJUDo">s</hi></abbr><ex xml:id="AJUDy">uli</ex></expan></w></roleName> <g ref="#ivy-leaf" xml:id="AJUDΙ">❦</g>
+                    <lb n="3" xml:id="AJUDΤ"/><w xml:id="AJUDε" n="45">optimo</w> <roleName type="civic" subtype="civis" xml:id="AJUDο"><w xml:id="AJUEA" n="50">civi</w></roleName> <w xml:id="AJUEK" n="55">ac</w> <roleName type="paracivic" subtype="patronus" xml:id="AJUEU"><w xml:id="AJUEe" n="60">patrono</w></roleName> <w xml:id="AJUEo" n="65">bene</w> <w xml:id="AJUEy" n="70">me
+                    <lb n="4" break="no" xml:id="AJUEΙ"/>renti</w> <g ref="#ivy-leaf" xml:id="AJUEΤ">❦</g> <space unit="character" quantity="3" xml:id="AJUEε"/><w xml:id="AJUEο" n="75">ordo</w> <w xml:id="AJUFA" n="80">et</w> <w xml:id="AJUFK" n="85">popu<hi rend="tall" xml:id="AJUFU">l</hi>us</w> <w xml:id="AJUFe" n="90">splen
+                    <lb n="5" break="no" xml:id="AJUFo"/><supplied reason="lost" xml:id="AJUFy">d</supplied>idis<hi rend="tall" xml:id="AJUFΙ">s</hi>imae</w> <placeName type="ancient" xml:id="AJUFΤ"><w xml:id="AJUFε" n="95"><expan xml:id="AJUFο"><abbr xml:id="AJUGA">col</abbr><ex xml:id="AJUGK">oniae</ex></expan></w> <w xml:id="AJUGU" n="100"><expan xml:id="AJUGe"><abbr xml:id="AJUGo">Aug</abbr><ex xml:id="AJUGy">ustae</ex></expan></w> <w xml:id="AJUGΙ" n="105">Himereorum</w>
+                    <lb n="6" xml:id="AJUGΤ"/><w xml:id="AJUGε" n="110"><expan xml:id="AJUGο"><abbr xml:id="AJUHA"><supplied reason="lost" xml:id="AJUHK">The</supplied>rmi<hi rend="tall" xml:id="AJUHU">t</hi></abbr><ex xml:id="AJUHe">anorum</ex></expan></w></placeName> <g ref="#ivy-leaf" xml:id="AJUHo">❦</g> <space unit="character" quantity="1" xml:id="AJUHy"/><w xml:id="AJUHΙ" n="115">pecunia</w> <w xml:id="AJUHΤ" n="120">sua</w> <w xml:id="AJUHε" n="125">posui<hi rend="tall" xml:id="AJUHο">t</hi></w>
+                </ab>
+            </div>
+            <div type="edition" subtype="simple-lemmatized">
+                <ab>
+                    <w n="5" lemma="Caius">Caio</w>
+                    <w n="10" lemma="Maesius">Maesio</w>
+                    <w n="15" lemma="Aquillius">Aquillio</w>
+                    <w n="20" lemma="Fabius">Fabio</w>
+                    <w n="25" lemma="Titianus">Titiano</w>
+                    <w n="30" lemma="clarus">clarissimo</w>
+                    <w n="35" lemma="vir">viro</w>
+                    <w n="40" lemma="consul">consuli</w>
+                    <w n="45" lemma="bonus">optimo</w>
+                    <w n="50" lemma="civis">civi</w>
+                    <w n="55" lemma="ac">ac</w>
+                    <w n="60" lemma="patronus">patrono</w>
+                    <w n="65" lemma="bonus">bene</w>
+                    <w n="70" lemma="mereor">merenti</w>
+                    <w n="75" lemma="ordo">ordo</w>
+                    <w n="80" lemma="et">et</w>
+                    <w n="85" lemma="populus">populus</w>
+                    <w n="90" lemma="splendidus">splendidissimae</w>
+                    <w n="95" lemma="colonia">coloniae</w>
+                    <w n="100" lemma="Augusta">Augustae</w>
+                    <w n="105" lemma="Himerei">Himereorum</w>
+                    <w n="110" lemma="Thermitani">Thermitanorum</w>
+                    <w n="115" lemma="pecunia">pecunia</w>
+                    <w n="120" lemma="suus">sua</w>
+                    <w n="125" lemma="pono">posuit</w>
                 </ab>
             </div>
             <div type="apparatus">
                 <listApp>
-                    <app><note>Text from autopsy</note></app>
+                    <app>
+                        <note>Text from autopsy</note>
+                    </app>
                 </listApp>
             </div>
             <div type="translation" xml:lang="en" resp="#TA #JP">
                 <p>To Gaius Maesius Aquillius Fabius Titianus, a most illustrious man (i.e. of senatorial class), consul, an excellent citizen and patron, well-deserving -  the council and people of the most splendid Colonia Augusta Himereorum Thermitanorum erected this at their own expense.</p>
             </div>
             <div type="commentary">
-                <p><!--commented out pending revision-->
-                    <!--Dedicated to consul and patron of the city, by the colonia of Thermae.--></p>
+                <p>
+                    <!--commented out pending revision-->
+                    <!--Dedicated to consul and patron of the city, by the colonia of Thermae.-->
+                </p>
             </div>
             <div type="bibliography">
                 <listBibl type="edition">
@@ -255,7 +293,7 @@
                             <ref target="http://arachne.uni-koeln.de/item/buchseite/650796">10.7345</ref>
                         </citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/GQN8UZSI"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10000589">https://biblio.inscriptiones.org/epig10000589</ref>
+                        <ref target="https://biblio.inscriptiones.org/epig10000589">https://biblio.inscriptiones.org/epig10000589</ref>
                     </bibl>
                     <bibl>
                         <author>Fazello</author>
@@ -295,30 +333,32 @@
                     <bibl type="corpus" n="ILMusTermini">
                         <citedRange>9</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/JCV85C79"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002137">https://biblio.inscriptiones.org/epig10002137</ref>
+                        <ref target="https://biblio.inscriptiones.org/epig10002137">https://biblio.inscriptiones.org/epig10002137</ref>
                     </bibl>
                     <bibl>
                         <author>Manganaro</author>
                         <date>1982</date>
                         <citedRange>375</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/7IFS6HUP"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001834">https://biblio.inscriptiones.org/epig10001834</ref>
+                        <ref target="https://biblio.inscriptiones.org/epig10001834">https://biblio.inscriptiones.org/epig10001834</ref>
                     </bibl>
                     <bibl>
                         <author>Manganaro</author>
                         <date>1988</date>
                         <citedRange>79</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/RZSFKACR"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001427">https://biblio.inscriptiones.org/epig10001427</ref>
+                        <ref target="https://biblio.inscriptiones.org/epig10001427">https://biblio.inscriptiones.org/epig10001427</ref>
                     </bibl>
                     <bibl>
                         <author>Amata</author>
                         <date>2015</date>
                         <ptr target="http://zotero.org/groups/382445/items/UK3583CG"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002629">https://biblio.inscriptiones.org/epig10002629</ref>
+                        <ref target="https://biblio.inscriptiones.org/epig10002629">https://biblio.inscriptiones.org/epig10002629</ref>
                     </bibl>
                 </listBibl>
-	   <listBibl type="discussion"><bibl/></listBibl>
+                <listBibl type="discussion">
+                    <bibl/>
+                </listBibl>
             </div>
         </body>
     </text>

--- a/inscriptions/ISic000099.xml
+++ b/inscriptions/ISic000099.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../schematron/ircyr-checking.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">
@@ -9,7 +9,9 @@
                 <editor ref="#JP">Jonathan Prag</editor>
                 <principal ref="#JP">Jonathan Prag</principal>
                 <funder>John Fell OUP Research Fund</funder>
-	   <funder><ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref></funder>
+                <funder>
+                    <ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref>
+                </funder>
                 <respStmt>
                     <name xml:id="JP" ref="http://orcid.org/0000-0003-3819-8537">Jonathan Prag</name>
                     <resp>original data collection and editing</resp>
@@ -34,11 +36,11 @@
                     <name xml:id="TA" ref="https://orcid.org/0000-0001-8417-7089">Tuuli Ahlholm</name>
                     <resp>EpiDoc editing</resp>
                 </respStmt>
-	    <respStmt>
-     	       <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
-     	       <resp>standardisation of template and tidying up encoding</resp>
- 	   </respStmt>
-	    <respStmt>
+                <respStmt>
+                    <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
+                    <resp>standardisation of template and tidying up encoding</resp>
+                </respStmt>
+                <respStmt>
                     <name xml:id="system">system</name>
                     <resp>automated or batch processes</resp>
                 </respStmt>
@@ -82,7 +84,8 @@
                     <physDesc>
                         <objectDesc>
                             <supportDesc>
-                                <support><p>Stele with tapered sides and rounded top, although with a straight break across the top left which obscures the beginning of the first line. Sides abraded. The epigraphic field has been chiselled back from the surface on the upper half of the front face, ending roughly half-way down stone, with an almost horizontal division between the chiselled and non-chiselled portions. Rear is extremely flat.</p>
+                                <support>
+                                    <p>Stele with tapered sides and rounded top, although with a straight break across the top left which obscures the beginning of the first line. Sides abraded. The epigraphic field has been chiselled back from the surface on the upper half of the front face, ending roughly half-way down stone, with an almost horizontal division between the chiselled and non-chiselled portions. Rear is extremely flat.</p>
                                     <material ana="#material.stone.limestone" ref="http://www.eagle-network.eu/voc/material/lod/66.html">limestone</material>
                                     <objectType ana="#object.stele" ref="http://www.eagle-network.eu/voc/objtyp/lod/250">stele</objectType>
                                     <dimensions>
@@ -92,12 +95,13 @@
                                     </dimensions>
                                 </support>
                                 <condition/>
-		    </supportDesc>
+                            </supportDesc>
                             <layoutDesc>
-                                <layout><p>Eight lines of Latin text, in centre (but not centred) of stone. Use of triangular interpuncts, although some are faint and indistinct. Interpuncts are not used between every word. Line 1 is notably larger, line 2 reduces, the other lines much smaller.</p>
+                                <layout>
+                                    <p>Eight lines of Latin text, in centre (but not centred) of stone. Use of triangular interpuncts, although some are faint and indistinct. Interpuncts are not used between every word. Line 1 is notably larger, line 2 reduces, the other lines much smaller.</p>
                                     <rs ana="#execution.chiselled" ref="http://www.eagle-network.eu/voc/writing/lod/1">chiselled</rs>
-                                	<damage/>
-			</layout>
+                                    <damage/>
+                                </layout>
                             </layoutDesc>
                         </objectDesc>
                         <handDesc>
@@ -145,12 +149,12 @@
                     <history>
                         <origin>
                             <origPlace>
-                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462513">Thermae Himeraeae</placeName>		
+                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462513">Thermae Himeraeae</placeName>
                                 <placeName type="modern" ref="http://sws.geonames.org/6539140">Termini Imerese</placeName>
-                            	<geo>37.98365, 13.69555</geo>
-		</origPlace>
-                        <origDate datingMethod="#julian" notBefore-custom="0069" notAfter-custom="0100" cert="low" source="https://www.zotero.org/groups/382445/items/KPXRWHDP" evidence="textual-context">The dating is contested by Bivona (later C1 CE, post-69) and Manganaro (a date shortly after 310-313 CE), based upon the reading of the word after 'Victoria' in line 4 (Bivona prefers Ticiniana, Manganaro Licininia). The other features of the text would seem to favour a later first rather than a fourth-century date.</origDate>
-                           <!-- <origDate datingMethod="#julian" notBefore-custom="0310" notAfter-custom="0313" cert="low" source="https://www.zotero.org/groups/382445/items/EZMBJ6GN">Manganaro (1989) asserts that the inscription must post-date 310/313 CE, based on his reading of victoria Liciniana in line 4.</origDate>-->
+                                <geo>37.98365, 13.69555</geo>
+                            </origPlace>
+                            <origDate datingMethod="#julian" notBefore-custom="0069" notAfter-custom="0100" cert="low" source="https://www.zotero.org/groups/382445/items/KPXRWHDP" evidence="textual-context">The dating is contested by Bivona (later C1 CE, post-69) and Manganaro (a date shortly after 310-313 CE), based upon the reading of the word after 'Victoria' in line 4 (Bivona prefers Ticiniana, Manganaro Licininia). The other features of the text would seem to favour a later first rather than a fourth-century date.</origDate>
+                            <!-- <origDate datingMethod="#julian" notBefore-custom="0310" notAfter-custom="0313" cert="low" source="https://www.zotero.org/groups/382445/items/EZMBJ6GN">Manganaro (1989) asserts that the inscription must post-date 310/313 CE, based on his reading of victoria Liciniana in line 4.</origDate>-->
                         </origin>
                         <provenance type="found" subtype="discovered" when="1950">Found in December 1950 in Termini Imerese, 'on the right of the Barratina stream [...] in the excavations for the foundation of a mill'. Quoted from Bivona 1994, who quotes a letter dated to the 20th of December 1950 from the Honourable Inspector, Professor G. Navarra to the Soprintendenza alle Antichità for the province of Palermo and Trapani. The stele went subsequently sent to the Museum.</provenance>
                         <provenance type="observed" subtype="autopsied" when="2022-07-13" resp="#AA">Antoniou, 2022-07-13. On display in the courtyard portico of Museo Civico Baldassare Romano</provenance>
@@ -160,18 +164,18 @@
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
-             <p>Encoded following the latest EpiDoc guidelines</p>
-             <xi:include href="../alists/ISicily-taxonomies.xml">
-                 <xi:fallback>
-                     <p>Taxonomies for ISicily controlled values</p>
-                 </xi:fallback>
-             </xi:include>
-	  <xi:include href="../alists/charDecl.xml">
-	     <xi:fallback>
-	       <p>ISicily glyphs authority list</p>
-	     </xi:fallback>
-	   </xi:include>
-         </encodingDesc>
+            <p>Encoded following the latest EpiDoc guidelines</p>
+            <xi:include href="../alists/ISicily-taxonomies.xml">
+                <xi:fallback>
+                    <p>Taxonomies for ISicily controlled values</p>
+                </xi:fallback>
+            </xi:include>
+            <xi:include href="../alists/charDecl.xml">
+                <xi:fallback>
+                    <p>ISicily glyphs authority list</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
             <calendarDesc>
                 <calendar xml:id="julian">
@@ -179,17 +183,17 @@
                 </calendar>
             </calendarDesc>
             <langUsage>
-                <language ident="en">English</language> 
-                <language ident="it">Italian</language> 
-                <language ident="grc">Ancient Greek</language> 
-                <language ident="la">Latin</language> 
-                <language ident="he">Hebrew</language> 
+                <language ident="en">English</language>
+                <language ident="it">Italian</language>
+                <language ident="grc">Ancient Greek</language>
+                <language ident="la">Latin</language>
+                <language ident="he">Hebrew</language>
                 <language ident="phn">Phoenician</language>
                 <language ident="xpu">Punic</language>
-                <language ident="osc">Oscan</language> 
-                <language ident="xly">Elymian</language> 
-                <language ident="scx">Sikel</language>  
-                <language ident="sxc">Sikan</language>  
+                <language ident="osc">Oscan</language>
+                <language ident="xly">Elymian</language>
+                <language ident="scx">Sikel</language>
+                <language ident="sxc">Sikan</language>
             </langUsage>
             <textClass>
                 <keywords scheme="http://www.eagle-network.eu/voc/typeins.html">
@@ -202,16 +206,16 @@
                 <change when="2016-12-03" who="#JCu">James Cummings autogenerated EpiDoc output from database</change>
                 <change when="2017-11-16" who="#JP">Jonathan Prag edited a bibl element</change>
                 <change when="2018-05-18" who="#TA">Tuuli Ahlholm cleaned up the autogenerated text and added an apparatus</change>
-            	   <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
-            	   <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
-            	<change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
-		<change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
-	    <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
-            	<change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
-              <change when="2023-08-23" who="#JP">Jonathan Prag added image</change>  
-              <change when="2023-09-06" who="#AA">edition on basis of autopsy and photographs</change>
-               <change when="2024-02-14" who="#JP">Jonathan Prag made minor revisions, added second image</change>
-	</listChange>
+                <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
+                <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
+                <change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
+                <change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
+                <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
+                <change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
+                <change when="2023-08-23" who="#JP">Jonathan Prag added image</change>
+                <change when="2023-09-06" who="#AA">edition on basis of autopsy and photographs</change>
+                <change when="2024-02-14" who="#JP">Jonathan Prag made minor revisions, added second image</change>
+            </listChange>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -228,92 +232,142 @@
             <graphic n="print" url="ISic000099_copy2.jpg" height="3680px" width="5520px">
                 <desc>I.Sicily with the permission of the Assessorato Regionale dei Beni Culturali e dell’Identità Siciliana - Dipartimento dei Beni Culturali e dell’Identità Siciliana, photo J.Prag 08.07.2022</desc>
             </graphic>
-         </surface>
+        </surface>
     </facsimile>
     <text>
         <body>
             <div type="edition" xml:space="preserve" xml:lang="la" resp="#TA #AA">
                 <ab>
-                    <lb n="1" xml:id="AJοAK"/><persName type="attested" xml:id="AJοAU"><name xml:id="AJοAe"><expan xml:id="AJοAo"><abbr xml:id="AJοAy">C</abbr><ex xml:id="AJοAΙ">aio</ex></expan></name> <g ref="#interpunct" xml:id="AJοAΤ">·</g> <name xml:id="AJοAε">Popillio</name> <g ref="#interpunct" xml:id="AJοAο">·</g> <persName type="attested" xml:id="AJοBA"><name type="patronym" xml:id="AJοBK"><expan xml:id="AJοBU"><abbr xml:id="AJοBe">C</abbr><ex xml:id="AJοBo">ai</ex></expan></name></persName> <g ref="#interpunct" xml:id="AJοBy">·</g> <w xml:id="AJοBΙ"><expan xml:id="AJοBΤ"><abbr xml:id="AJοBε">f</abbr><ex xml:id="AJοBο">ilio</ex></expan></w> <g ref="#interpunct" xml:id="AJοCA">·</g> <orgName type="tribus" xml:id="AJοCK"><w xml:id="AJοCU"><expan xml:id="AJοCe"><abbr xml:id="AJοCo">Mae</abbr><ex xml:id="AJοCy">cia</ex></expan></w> <w xml:id="AJοCΙ"><supplied reason="subaudible" xml:id="AJοCΤ">tribu</supplied></w></orgName> 
-                    <lb n="2" xml:id="AJοCε"/><name xml:id="AJοCο"><supplied reason="lost" xml:id="AJοDA">P</supplied>risco</name></persName> <g ref="#interpunct" xml:id="AJοDK">·</g> <roleName type="military" subtype="miles" xml:id="AJοDU"><w xml:id="AJοDe"><expan xml:id="AJοDo"><abbr xml:id="AJοDy">mil</abbr><ex xml:id="AJοDΙ">iti</ex></expan></w></roleName> <g ref="#interpunct" xml:id="AJοDΤ">·</g> <w xml:id="AJοDε"><expan xml:id="AJοDο"><abbr xml:id="AJοEA">coh</abbr><ex xml:id="AJοEK">ortis</ex></expan></w> <g ref="#interpunct" xml:id="AJοEU">·</g> <num value="10" xml:id="AJοEe">X</num> <g ref="#interpunct" xml:id="AJοEo">·</g> <w xml:id="AJοEy"><expan xml:id="AJοEΙ"><abbr xml:id="AJοEΤ">urb</abbr><ex xml:id="AJοEε">anae</ex></expan></w> 
-                    <lb n="3" xml:id="AJοEο"/><supplied reason="lost" xml:id="AJοFA"><g ref="#centuria" xml:id="AJοFK">&#x1019B;</g></supplied><persName type="attested" xml:id="AJοFU"><name xml:id="AJοFe">Avilli</name> <name xml:id="AJοFo">Maximi</name></persName> <g ref="#interpunct" xml:id="AJοFy">·</g> <roleName type="military" subtype="optio" xml:id="AJοFΙ"><w xml:id="AJοFΤ">optioni</w></roleName> <g ref="#interpunct" xml:id="AJοFε">·</g> <w xml:id="AJοFο">a</w> 
-                    <lb n="4" xml:id="AJοGA"/><w xml:id="AJοGK">victoria</w> <w xml:id="AJοGU">Liciniana</w> <w xml:id="AJοGe">mil<supplied reason="omitted" xml:id="AJοGo">i</supplied>tavit</w> 
-                    <lb n="5" xml:id="AJοGy"/><w xml:id="AJοGΙ">annis</w> <g ref="#interpunct" xml:id="AJοGΤ">·</g> <num value="6" xml:id="AJοGε"><hi rend="supraline" xml:id="AJοGο">VI</hi></num> <g ref="#interpunct" xml:id="AJοHA">·</g> <w xml:id="AJοHK">mensibus</w> <num value="3" xml:id="AJοHU">III</num> <g ref="#interpunct" xml:id="AJοHe">·</g> <w xml:id="AJοHo">vixit</w> <g ref="#interpunct" xml:id="AJοHy">·</g> <w xml:id="AJοHΙ"><expan xml:id="AJοHΤ"><abbr xml:id="AJοHε">ann</abbr><ex xml:id="AJοHο">is</ex></expan></w> 
-                    <lb n="6" xml:id="AJοIA"/><num value="27" xml:id="AJοIK">XXVII</num> <g ref="#interpunct" xml:id="AJοIU">·</g> <w xml:id="AJοIe">mensibus</w> <num value="8" xml:id="AJοIo">VIII</num> <g ref="#interpunct" xml:id="AJοIy">·</g> <w xml:id="AJοIΙ">diebus</w> <g ref="#interpunct" xml:id="AJοIΤ">·</g> <num value="8" xml:id="AJοIε">VIII</num> 
-                    <lb n="7" xml:id="AJοIο"/><persName type="attested" xml:id="AJοJA"><name xml:id="AJοJK">Turrania</name> <g ref="#interpunct" xml:id="AJοJU">·</g> <persName type="attested" xml:id="AJοJe"><name type="patronym" xml:id="AJοJo"><expan xml:id="AJοJy"><abbr xml:id="AJοJΙ">P</abbr><ex xml:id="AJοJΤ">ubli</ex></expan></name></persName> <g ref="#interpunct" xml:id="AJοJε">·</g> <w xml:id="AJοJο"><expan xml:id="AJοKA"><abbr xml:id="AJοKK">f</abbr><ex xml:id="AJοKU">ilia</ex></expan></w> <g ref="#interpunct" xml:id="AJοKe">·</g> <name xml:id="AJοKo">Primilla</name></persName> <g ref="#interpunct" xml:id="AJοKy">·</g> <w xml:id="AJοKΙ">cognato</w> 
-                    <lb n="8" xml:id="AJοKΤ"/><w xml:id="AJοKε">bene</w> <w xml:id="AJοKο">mer<unclear xml:id="AJοLA">e</unclear>nti</w>
+                    <lb n="1" xml:id="AJοAK"/><persName type="attested" xml:id="AJοAU"><name xml:id="AJοAe"><w n="5"><expan xml:id="AJοAo"><abbr xml:id="AJοAy">C</abbr><ex xml:id="AJοAΙ">aio</ex></expan></w></name> <g ref="#interpunct" xml:id="AJοAΤ">·</g> <name xml:id="AJοAε"><w n="10">Popillio</w></name> <g ref="#interpunct" xml:id="AJοAο">·</g> <persName type="attested" xml:id="AJοBA"><name type="patronym" xml:id="AJοBK"><w n="15"><expan xml:id="AJοBU"><abbr xml:id="AJοBe">C</abbr><ex xml:id="AJοBo">ai</ex></expan></w></name></persName> <g ref="#interpunct" xml:id="AJοBy">·</g> <w xml:id="AJοBΙ" n="20"><expan xml:id="AJοBΤ"><abbr xml:id="AJοBε">f</abbr><ex xml:id="AJοBο">ilio</ex></expan></w> <g ref="#interpunct" xml:id="AJοCA">·</g> <orgName type="tribus" xml:id="AJοCK"><w xml:id="AJοCU" n="25"><expan xml:id="AJοCe"><abbr xml:id="AJοCo">Mae</abbr><ex xml:id="AJοCy">cia</ex></expan></w> <w xml:id="AJοCΙ" n="30"><supplied reason="subaudible" xml:id="AJοCΤ">tribu</supplied></w></orgName>
+                    <lb n="2" xml:id="AJοCε"/><name xml:id="AJοCο"><w n="35"><supplied reason="lost" xml:id="AJοDA">P</supplied>risco</w></name></persName> <g ref="#interpunct" xml:id="AJοDK">·</g> <roleName type="military" subtype="miles" xml:id="AJοDU"><w xml:id="AJοDe" n="40"><expan xml:id="AJοDo"><abbr xml:id="AJοDy">mil</abbr><ex xml:id="AJοDΙ">iti</ex></expan></w></roleName> <g ref="#interpunct" xml:id="AJοDΤ">·</g> <w xml:id="AJοDε" n="45"><expan xml:id="AJοDο"><abbr xml:id="AJοEA">coh</abbr><ex xml:id="AJοEK">ortis</ex></expan></w> <g ref="#interpunct" xml:id="AJοEU">·</g> <num value="10" xml:id="AJοEe"><w n="50">X</w></num> <g ref="#interpunct" xml:id="AJοEo">·</g> <w xml:id="AJοEy" n="55"><expan xml:id="AJοEΙ"><abbr xml:id="AJοEΤ">urb</abbr><ex xml:id="AJοEε">anae</ex></expan></w>
+                    <lb n="3" xml:id="AJοEο"/><supplied reason="lost" xml:id="AJοFA"><g ref="#centuria" xml:id="AJοFK">𐆛</g></supplied><persName type="attested" xml:id="AJοFU"><name xml:id="AJοFe"><w n="60">Avilli</w></name> <name xml:id="AJοFo"><w n="65">Maximi</w></name></persName> <g ref="#interpunct" xml:id="AJοFy">·</g> <roleName type="military" subtype="optio" xml:id="AJοFΙ"><w xml:id="AJοFΤ" n="70">optioni</w></roleName> <g ref="#interpunct" xml:id="AJοFε">·</g> <w xml:id="AJοFο" n="75">a</w>
+                    <lb n="4" xml:id="AJοGA"/><w xml:id="AJοGK" n="80">victoria</w> <w xml:id="AJοGU" n="85">Liciniana</w> <w xml:id="AJοGe" n="90">mil<supplied reason="omitted" xml:id="AJοGo">i</supplied>tavit</w>
+                    <lb n="5" xml:id="AJοGy"/><w xml:id="AJοGΙ" n="95">annis</w> <g ref="#interpunct" xml:id="AJοGΤ">·</g> <num value="6" xml:id="AJοGε"><w n="100"><hi rend="supraline" xml:id="AJοGο">VI</hi></w></num> <g ref="#interpunct" xml:id="AJοHA">·</g> <w xml:id="AJοHK" n="105">mensibus</w> <num value="3" xml:id="AJοHU"><w n="110">III</w></num> <g ref="#interpunct" xml:id="AJοHe">·</g> <w xml:id="AJοHo" n="115">vixit</w> <g ref="#interpunct" xml:id="AJοHy">·</g> <w xml:id="AJοHΙ" n="120"><expan xml:id="AJοHΤ"><abbr xml:id="AJοHε">ann</abbr><ex xml:id="AJοHο">is</ex></expan></w>
+                    <lb n="6" xml:id="AJοIA"/><num value="27" xml:id="AJοIK"><w n="125">XXVII</w></num> <g ref="#interpunct" xml:id="AJοIU">·</g> <w xml:id="AJοIe" n="130">mensibus</w> <num value="8" xml:id="AJοIo"><w n="135">VIII</w></num> <g ref="#interpunct" xml:id="AJοIy">·</g> <w xml:id="AJοIΙ" n="140">diebus</w> <g ref="#interpunct" xml:id="AJοIΤ">·</g> <num value="8" xml:id="AJοIε"><w n="145">VIII</w></num>
+                    <lb n="7" xml:id="AJοIο"/><persName type="attested" xml:id="AJοJA"><name xml:id="AJοJK"><w n="150">Turrania</w></name> <g ref="#interpunct" xml:id="AJοJU">·</g> <persName type="attested" xml:id="AJοJe"><name type="patronym" xml:id="AJοJo"><w n="155"><expan xml:id="AJοJy"><abbr xml:id="AJοJΙ">P</abbr><ex xml:id="AJοJΤ">ubli</ex></expan></w></name></persName> <g ref="#interpunct" xml:id="AJοJε">·</g> <w xml:id="AJοJο" n="160"><expan xml:id="AJοKA"><abbr xml:id="AJοKK">f</abbr><ex xml:id="AJοKU">ilia</ex></expan></w> <g ref="#interpunct" xml:id="AJοKe">·</g> <name xml:id="AJοKo"><w n="165">Primilla</w></name></persName> <g ref="#interpunct" xml:id="AJοKy">·</g> <w xml:id="AJοKΙ" n="170">cognato</w>
+                    <lb n="8" xml:id="AJοKΤ"/><w xml:id="AJοKε" n="175">bene</w> <w xml:id="AJοKο" n="180">mer<unclear xml:id="AJοLA">e</unclear>nti</w>
+                </ab>
+            </div>
+            <div type="edition" subtype="simple-lemmatized">
+                <ab>
+                    <w n="5" lemma="Caius">Caio</w>
+                    <w n="10" lemma="Popillius">Popillio</w>
+                    <w n="15" lemma="Caius">Cai</w>
+                    <w n="20" lemma="filius">filio</w>
+                    <w n="25" lemma="Maecius">Maecia</w>
+                    <w n="30" lemma="tribus">tribu</w>
+                    <w n="35" lemma="Priscus">Prisco</w>
+                    <w n="40" lemma="miles">militi</w>
+                    <w n="45" lemma="cohors">cohortis</w>
+                    <w n="50" lemma="X">X</w>
+                    <w n="55" lemma="urbanus">urbanae</w>
+                    <w n="60" lemma="Avillus">Avilli</w>
+                    <w n="65" lemma="Maximus">Maximi</w>
+                    <w n="70" lemma="optio">optioni</w>
+                    <w n="75" lemma="a">a</w>
+                    <w n="80" lemma="victoria">victoria</w>
+                    <w n="85" lemma="Licinianus">Liciniana</w>
+                    <w n="90" lemma="milito">militavit</w>
+                    <w n="95" lemma="annus">annis</w>
+                    <w n="100" lemma="VI">VI</w>
+                    <w n="105" lemma="mensis">mensibus</w>
+                    <w n="110" lemma="III">III</w>
+                    <w n="115" lemma="vivo">vixit</w>
+                    <w n="120" lemma="annus">annis</w>
+                    <w n="125" lemma="XXVII">XXVII</w>
+                    <w n="130" lemma="mensis">mensibus</w>
+                    <w n="135" lemma="VIII">VIII</w>
+                    <w n="140" lemma="dies">diebus</w>
+                    <w n="145" lemma="VIII">VIII</w>
+                    <w n="150" lemma="Turrania">Turrania</w>
+                    <w n="155" lemma="Publius">Publi</w>
+                    <w n="160" lemma="filia">filia</w>
+                    <w n="165" lemma="Primilla">Primilla</w>
+                    <w n="170" lemma="cognatus">cognato</w>
+                    <w n="175" lemma="bonus">bene</w>
+                    <w n="180" lemma="mereor">merenti</w>
                 </ab>
             </div>
             <div type="apparatus" resp="#AA">
                 <listApp>
-                    <app><note>Text from autopsy (Antoniou)</note></app>
-                    <app loc="4"><note>There are traces of a very faint horizontal bar at the bottom of the first letter after Victoria. By comparison with the T in Turrania on line 7, I prefer reading Liciniana rather than Ticiniana, contra Bivona (1978; 1994). Contra Bivona (1994), but I read 'MILTAVIT' on stone, rather than 'MIITAVIT'. The first 'I' in MILTAVIT is difficult to read: the slight curve on the letter suggests it is an 's', especially in comparison with 's' elsewhere on stone, but difficult to find an alternative reading.</note></app>
-                    <app loc="5"><note>Contra Bivona (1994), but there is evidence of a supralinear line over VI</note></app>
+                    <app>
+                        <note>Text from autopsy (Antoniou)</note>
+                    </app>
+                    <app loc="4">
+                        <note>There are traces of a very faint horizontal bar at the bottom of the first letter after Victoria. By comparison with the T in Turrania on line 7, I prefer reading Liciniana rather than Ticiniana, contra Bivona (1978; 1994). Contra Bivona (1994), but I read 'MILTAVIT' on stone, rather than 'MIITAVIT'. The first 'I' in MILTAVIT is difficult to read: the slight curve on the letter suggests it is an 's', especially in comparison with 's' elsewhere on stone, but difficult to find an alternative reading.</note>
+                    </app>
+                    <app loc="5">
+                        <note>Contra Bivona (1994), but there is evidence of a supralinear line over VI</note>
+                    </app>
                 </listApp>
             </div>
             <div type="translation" xml:lang="en" resp="#AA">
                 <p>To Gaius Popillius Priscus, son of Gaius, of tribe Maecia, of the 10th Urban cohort, the Avillus Maximus century. After the Licinian victory, he served as optio for 6 years and 3 months. He lived for 28 years, 8 months, 8 days. Turrania Primilla, daughter of Publius, [set this up] for her well-deserving relative.</p>
             </div>
             <div type="commentary">
-                <p>While there is another Popillius attested in Thermae Himeraeae <ref target="http://sicily.classics.ox.ac.uk/inscription/ISic000117">ISic00117</ref>, that Popillius likely belongs to the Pollia tribe, and thus there is likely no connection between the two individuals. For Turrania, there is only one other attestion of the name in Sicily, in its masculine form, from Halaesa <ref target="http://sicily.classics.ox.ac.uk/inscription/ISic003576">ISic003576</ref>, but is extremely common elsewhere in the empire. Although there is some uncertainty, given the condition of the front face of the inscription, it appears that line 4 reads 'victoria Liciniana' (following the reading of Manganaro (1989)), who subsequently dated the inscription to a victoria Liciniana of Licinius, either in 310 or 313 CE, either in Raetia or at Campus Egrenus in Thrace. As Ricci (C. Ricci, "In Custodiam Urbis: Notes on the Cohortes Urbanae (1968-2010)", Historia 60.4 (2011), 484–508, at 503) emphasises, however, the complete onomastic formula with tribal affiliation attested in an inscription for a miles urbanicianus makes a fourth-century CE date for this inscription 'difficult to justify', although Bivona (1994) is less certain of this as an absolute requirement. Ricci (2011) and Bivona (1978; 1994) prefer then to read victoria Ticiniana, and date the inscription on the basis of a battle between the armies of Vitellius and Otho in March/April of 69 CE, to match the testimony of Tacitus (Histories, 1.87.1, 1.89.1, 2.21.4, 2.17.2), who attests to the involvement of urban cohorts at the time. Bivona (1994) considers the questions of this inscription to be a continuing problem, and is not entirely happy with the solution she proposed.</p>
+                <p>
+                    While there is another Popillius attested in Thermae Himeraeae<ref target="http://sicily.classics.ox.ac.uk/inscription/ISic000117">ISic00117</ref>, that Popillius likely belongs to the Pollia tribe, and thus there is likely no connection between the two individuals. For Turrania, there is only one other attestion of the name in Sicily, in its masculine form, from Halaesa
+                    <ref target="http://sicily.classics.ox.ac.uk/inscription/ISic003576">ISic003576</ref>, but is extremely common elsewhere in the empire. Although there is some uncertainty, given the condition of the front face of the inscription, it appears that line 4 reads 'victoria Liciniana' (following the reading of Manganaro (1989)), who subsequently dated the inscription to a victoria Liciniana of Licinius, either in 310 or 313 CE, either in Raetia or at Campus Egrenus in Thrace. As Ricci (C. Ricci, "In Custodiam Urbis: Notes on the Cohortes Urbanae (1968-2010)", Historia 60.4 (2011), 484–508, at 503) emphasises, however, the complete onomastic formula with tribal affiliation attested in an inscription for a miles urbanicianus makes a fourth-century CE date for this inscription 'difficult to justify', although Bivona (1994) is less certain of this as an absolute requirement. Ricci (2011) and Bivona (1978; 1994) prefer then to read victoria Ticiniana, and date the inscription on the basis of a battle between the armies of Vitellius and Otho in March/April of 69 CE, to match the testimony of Tacitus (Histories, 1.87.1, 1.89.1, 2.21.4, 2.17.2), who attests to the involvement of urban cohorts at the time. Bivona (1994) considers the questions of this inscription to be a continuing problem, and is not entirely happy with the solution she proposed.
+                </p>
             </div>
             <div type="bibliography">
                 <listBibl type="edition">
                     <bibl type="bulletin" n="AE">
                         <citedRange>2011.0438</citedRange>
                         <ptr target="http://zotero.org/groups/382445/items/R46KDTZX"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001283">https://biblio.inscriptiones.org/epig10001283</ref>
+                        <ref target="https://biblio.inscriptiones.org/epig10001283">https://biblio.inscriptiones.org/epig10001283</ref>
                     </bibl>
                     <bibl type="bulletin" n="AE">
                         <citedRange>1989.0345e</citedRange>
                         <ptr target="http://zotero.org/groups/382445/items/R46KDTZX"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001283">https://biblio.inscriptiones.org/epig10001283</ref>
+                        <ref target="https://biblio.inscriptiones.org/epig10001283">https://biblio.inscriptiones.org/epig10001283</ref>
                     </bibl>
                     <bibl type="bulletin" n="AE">
                         <citedRange>1978.0374</citedRange>
                         <ptr target="http://zotero.org/groups/382445/items/R46KDTZX"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001283">https://biblio.inscriptiones.org/epig10001283</ref>
+                        <ref target="https://biblio.inscriptiones.org/epig10001283">https://biblio.inscriptiones.org/epig10001283</ref>
                     </bibl>
                     <bibl type="corpus" n="ILMusTermini">
                         <citedRange>17</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/JCV85C79"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002137">https://biblio.inscriptiones.org/epig10002137</ref>
+                        <ref target="https://biblio.inscriptiones.org/epig10002137">https://biblio.inscriptiones.org/epig10002137</ref>
                     </bibl>
                     <bibl>
                         <author>Wilson</author>
                         <date>1990</date>
                         <citedRange>359 n.60</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/VF9MMBI9"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001509">https://biblio.inscriptiones.org/epig10001509</ref>
+                        <ref target="https://biblio.inscriptiones.org/epig10001509">https://biblio.inscriptiones.org/epig10001509</ref>
                     </bibl>
                     <bibl>
                         <author>Manganaro</author>
                         <date>1989</date>
                         <citedRange>189 no.79 fig.83</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/EZMBJ6GN"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001831">https://biblio.inscriptiones.org/epig10001831</ref>
+                        <ref target="https://biblio.inscriptiones.org/epig10001831">https://biblio.inscriptiones.org/epig10001831</ref>
                     </bibl>
                     <bibl>
                         <author>Bivona</author>
                         <date>1978</date>
                         <ptr target="https://www.zotero.org/groups/382445/items/KPXRWHDP"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002138">https://biblio.inscriptiones.org/epig10002138</ref>
+                        <ref target="https://biblio.inscriptiones.org/epig10002138">https://biblio.inscriptiones.org/epig10002138</ref>
                     </bibl>
                     <bibl>
                         <author>Manganaro</author>
                         <date>1988</date>
                         <citedRange>41, 71</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/RZSFKACR"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001427">https://biblio.inscriptiones.org/epig10001427</ref>
+                        <ref target="https://biblio.inscriptiones.org/epig10001427">https://biblio.inscriptiones.org/epig10001427</ref>
                     </bibl>
                 </listBibl>
-	   <listBibl type="discussion">
-	       <bibl>
-	           <author>Ricci</author>
-	           <date>2011</date>
-	           <citedRange>503</citedRange> <!-- To add: Full citation: Cecilia Ricci (2011) In Custodiam Urbis: Notes on the Cohortes Urbanae (1968-2010). Historia. 60.4: 484–508  -->
-	       </bibl>
-	   </listBibl>
+                <listBibl type="discussion">
+                    <bibl>
+                        <author>Ricci</author>
+                        <date>2011</date>
+                        <citedRange>503</citedRange>
+                        <!-- To add: Full citation: Cecilia Ricci (2011) In Custodiam Urbis: Notes on the Cohortes Urbanae (1968-2010). Historia. 60.4: 484–508  -->
+                    </bibl>
+                </listBibl>
             </div>
         </body>
     </text>

--- a/inscriptions/ISic000103.xml
+++ b/inscriptions/ISic000103.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../schematron/ircyr-checking.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">
@@ -9,7 +9,9 @@
                 <editor ref="#JP">Jonathan Prag</editor>
                 <principal ref="#JP">Jonathan Prag</principal>
                 <funder>John Fell OUP Research Fund</funder>
-	   <funder><ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref></funder>
+                <funder>
+                    <ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref>
+                </funder>
                 <respStmt>
                     <name xml:id="JP" ref="http://orcid.org/0000-0003-3819-8537">Jonathan Prag</name>
                     <resp>original data collection and editing</resp>
@@ -33,12 +35,12 @@
                 <respStmt>
                     <name xml:id="TA" ref="https://orcid.org/0000-0001-8417-7089">Tuuli Ahlholm</name>
                     <resp>EpiDoc editing</resp>
-                </respStmt> 
-             <respStmt>
-     	       <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
-     	       <resp>standardisation of template and tidying up encoding</resp>
- 	   </respStmt>
-	    <respStmt>
+                </respStmt>
+                <respStmt>
+                    <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
+                    <resp>standardisation of template and tidying up encoding</resp>
+                </respStmt>
+                <respStmt>
                     <name xml:id="system">system</name>
                     <resp>automated or batch processes</resp>
                 </respStmt>
@@ -78,7 +80,8 @@
                     <physDesc>
                         <objectDesc>
                             <supportDesc>
-                                <support><p>Rectangular block of coarse grey limestone (with a diagonal pale vein running across the left corner). The block is roughly finished on each side, the rear is uneven, projecting out significantly in the central part. The lower right corner is lost, and there is some wear/loss to the upper left corner. The face has been carved to create a tabula ansata with relief moulded frame and small triangular 'ears', and a recessed epigraphic field in the centre (18 cm H x 40.2cm W).</p>
+                                <support>
+                                    <p>Rectangular block of coarse grey limestone (with a diagonal pale vein running across the left corner). The block is roughly finished on each side, the rear is uneven, projecting out significantly in the central part. The lower right corner is lost, and there is some wear/loss to the upper left corner. The face has been carved to create a tabula ansata with relief moulded frame and small triangular 'ears', and a recessed epigraphic field in the centre (18 cm H x 40.2cm W).</p>
                                     <material ana="#material.stone.limestone" ref="http://www.eagle-network.eu/voc/material/lod/66.html">limestone</material>
                                     <objectType ana="#object.block" ref="http://www.eagle-network.eu/voc/objtyp/lod/189.html">block</objectType>
                                     <dimensions>
@@ -88,16 +91,18 @@
                                     </dimensions>
                                 </support>
                                 <condition/>
-		    </supportDesc>
+                            </supportDesc>
                             <layoutDesc>
-                                <layout><p>Three lines of text filling the available field, the first line substantially larger than the second and third, with an attempt to centre the middle line.</p>
+                                <layout>
+                                    <p>Three lines of text filling the available field, the first line substantially larger than the second and third, with an attempt to centre the middle line.</p>
                                     <rs ana="#execution.chiselled" ref="http://www.eagle-network.eu/voc/writing/lod/1">chiselled</rs>
-                                	<damage/>
-			</layout>
+                                    <damage/>
+                                </layout>
                             </layoutDesc>
                         </objectDesc>
                         <handDesc>
-                            <handNote><p>Tall, slimly v-cut letters, with comma shaped interpuncts often enclosed in the letters due to cramping of the text. Substantial serifs on some letters in line 1.</p>
+                            <handNote>
+                                <p>Tall, slimly v-cut letters, with comma shaped interpuncts often enclosed in the letters due to cramping of the text. Substantial serifs on some letters in line 1.</p>
                                 <locus from="line1" to="line1">Line 1</locus>
                                 <dimensions type="letterHeight">
                                     <height unit="mm">66-72</height>
@@ -124,10 +129,10 @@
                     <history>
                         <origin>
                             <origPlace>
-                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462513" cert="low">Thermae Himeraeae</placeName>		
+                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462513" cert="low">Thermae Himeraeae</placeName>
                                 <placeName type="modern" ref="http://sws.geonames.org/6539140">Termini Imerese</placeName>
-                            	<geo>37.98365, 13.69555</geo>
-		</origPlace>
+                                <geo>37.98365, 13.69555</geo>
+                            </origPlace>
                             <origDate datingMethod="#julian" notBefore-custom="0001" notAfter-custom="0300" cert="low">Imperial</origDate>
                         </origin>
                         <provenance type="found" subtype="discovered" notAfter="1766">First recorded by Tardia in 1766, who saw it 'in aedibus baronis Aegidii Puccii'; it was subsequently transferred to the civic museum. It is reasonable to assume it is from Termini.</provenance>
@@ -138,18 +143,18 @@
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
-             <p>Encoded following the latest EpiDoc guidelines</p>
-             <xi:include href="../alists/ISicily-taxonomies.xml">
-                 <xi:fallback>
-                     <p>Taxonomies for ISicily controlled values</p>
-                 </xi:fallback>
-             </xi:include>
-	  <xi:include href="../alists/charDecl.xml">
-	     <xi:fallback>
-	       <p>ISicily glyphs authority list</p>
-	     </xi:fallback>
-	   </xi:include>
-         </encodingDesc>
+            <p>Encoded following the latest EpiDoc guidelines</p>
+            <xi:include href="../alists/ISicily-taxonomies.xml">
+                <xi:fallback>
+                    <p>Taxonomies for ISicily controlled values</p>
+                </xi:fallback>
+            </xi:include>
+            <xi:include href="../alists/charDecl.xml">
+                <xi:fallback>
+                    <p>ISicily glyphs authority list</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
             <calendarDesc>
                 <calendar xml:id="julian">
@@ -179,15 +184,15 @@
             <listChange>
                 <change when="2016-12-03" who="#JCu">James Cummings autogenerated EpiDoc output from database</change>
                 <change when="2018-10-16" who="#TA">Tuuli Ahlholm cleaned up the autogenerated text and added an apparatus and translation</change>
-            	   <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
-            	   <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
-            	<change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
-		<change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
-	    <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
-            	<change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
+                <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
+                <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
+                <change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
+                <change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
+                <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
+                <change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
                 <change when="2023-08-23" who="#JP">Jonathan Prag added image</change>
                 <change when="2024-04-08" who="#JP">Jonathan Prag revised from autopsy</change>
-	</listChange>
+            </listChange>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -204,7 +209,7 @@
             <graphic n="print" url="ISic000103_copy2.jpg" height="3680px" width="5520px">
                 <desc>I.Sicily with the permission of the Assessorato Regionale dei Beni Culturali e dell’Identità Siciliana - Dipartimento dei Beni Culturali e dell’Identità Siciliana; photo J.Prag 2023-07-04</desc>
             </graphic>
-         </surface>
+        </surface>
         <surface type="rear">
             <graphic n="screen" url="ISic000103_rear_tiled.tif" height="3680px" width="5520px">
                 <desc>I.Sicily with the permission of the Assessorato Regionale dei Beni Culturali e dell’Identità Siciliana - Dipartimento dei Beni Culturali e dell’Identità Siciliana; photo J.Prag 2023-07-04</desc>
@@ -218,24 +223,42 @@
         <body>
             <div type="edition" xml:space="preserve" xml:lang="la" resp="#TA #JP">
                 <ab>
-                    <lb n="1" xml:id="AKeAK"/><persName type="attested" xml:id="AKeAU"><name xml:id="AKeAe"><expan xml:id="AKeAo"><abbr xml:id="AKeAy">C</abbr><ex xml:id="AKeAΙ">aio</ex></expan></name> <g ref="#interpunct" xml:id="AKeAΤ">·</g> <name xml:id="AKeAε">Virio</name> <g ref="#interpunct" xml:id="AKeAο">·</g> <persName type="attested" xml:id="AKeBA"><name type="patronym" xml:id="AKeBK"><expan xml:id="AKeBU"><abbr xml:id="AKeBe">C</abbr><ex xml:id="AKeBo">ai</ex></expan></name></persName> <g ref="#interpunct" xml:id="AKeBy">·</g> <w xml:id="AKeBΙ"><expan xml:id="AKeBΤ"><abbr xml:id="AKeBε">f</abbr><ex xml:id="AKeBο">ilio</ex></expan></w> <g ref="#interpunct" xml:id="AKeCA">·</g> <orgName xml:id="AKeCK"><w xml:id="AKeCU"><expan xml:id="AKeCe"><abbr xml:id="AKeCo">Cla</abbr><ex xml:id="AKeCy">udia</ex></expan></w></orgName> 
-                    <lb n="2" xml:id="AKeCΙ"/><name xml:id="AKeCΤ">Maximo</name></persName> <g ref="#interpunct" xml:id="AKeCε">·</g> <roleName type="religious" subtype="haruspex" xml:id="AKeCο"><w xml:id="AKeDA"><expan xml:id="AKeDK"><abbr xml:id="AKeDU">haruspic</abbr><ex xml:id="AKeDe">i</ex></expan></w></roleName> 
-                    <lb n="3" xml:id="AKeDo"/><persName type="attested" xml:id="AKeDy"><name xml:id="AKeDΙ">Clodiae</name> <g ref="#interpunct" xml:id="AKeDΤ">·</g> <persName type="attested" xml:id="AKeDε"><name type="libertinatio" xml:id="AKeDο"><expan xml:id="AKeEA"><abbr xml:id="AKeEK">M</abbr><ex xml:id="AKeEU">arci</ex></expan></name></persName> <g ref="#interpunct" xml:id="AKeEe">·</g> <w xml:id="AKeEo"><expan xml:id="AKeEy"><abbr xml:id="AKeEΙ">l</abbr><ex xml:id="AKeEΤ">ibertae</ex></expan></w> <g ref="#interpunct" xml:id="AKeEε">·</g> <name xml:id="AKeEο">Donatae</name></persName> <g ref="#interpunct" xml:id="AKeFA">·</g> <w xml:id="AKeFK"><expan xml:id="AKeFU"><abbr xml:id="AKeFe">m</abbr><ex cert="low" xml:id="AKeFo">erentibus</ex></expan></w>
+                    <lb n="1" xml:id="AKeAK"/><persName type="attested" xml:id="AKeAU"><name xml:id="AKeAe"><w n="5"><expan xml:id="AKeAo"><abbr xml:id="AKeAy">C</abbr><ex xml:id="AKeAΙ">aio</ex></expan></w></name> <g ref="#interpunct" xml:id="AKeAΤ">·</g> <name xml:id="AKeAε"><w n="10">Virio</w></name> <g ref="#interpunct" xml:id="AKeAο">·</g> <persName type="attested" xml:id="AKeBA"><name type="patronym" xml:id="AKeBK"><w n="15"><expan xml:id="AKeBU"><abbr xml:id="AKeBe">C</abbr><ex xml:id="AKeBo">ai</ex></expan></w></name></persName> <g ref="#interpunct" xml:id="AKeBy">·</g> <w xml:id="AKeBΙ" n="20"><expan xml:id="AKeBΤ"><abbr xml:id="AKeBε">f</abbr><ex xml:id="AKeBο">ilio</ex></expan></w> <g ref="#interpunct" xml:id="AKeCA">·</g> <orgName xml:id="AKeCK"><w xml:id="AKeCU" n="25"><expan xml:id="AKeCe"><abbr xml:id="AKeCo">Cla</abbr><ex xml:id="AKeCy">udia</ex></expan></w></orgName>
+                    <lb n="2" xml:id="AKeCΙ"/><name xml:id="AKeCΤ"><w n="30">Maximo</w></name></persName> <g ref="#interpunct" xml:id="AKeCε">·</g> <roleName type="religious" subtype="haruspex" xml:id="AKeCο"><w xml:id="AKeDA" n="35"><expan xml:id="AKeDK"><abbr xml:id="AKeDU">haruspic</abbr><ex xml:id="AKeDe">i</ex></expan></w></roleName>
+                    <lb n="3" xml:id="AKeDo"/><persName type="attested" xml:id="AKeDy"><name xml:id="AKeDΙ"><w n="40">Clodiae</w></name> <g ref="#interpunct" xml:id="AKeDΤ">·</g> <persName type="attested" xml:id="AKeDε"><name type="libertinatio" xml:id="AKeDο"><w n="45"><expan xml:id="AKeEA"><abbr xml:id="AKeEK">M</abbr><ex xml:id="AKeEU">arci</ex></expan></w></name></persName> <g ref="#interpunct" xml:id="AKeEe">·</g> <w xml:id="AKeEo" n="50"><expan xml:id="AKeEy"><abbr xml:id="AKeEΙ">l</abbr><ex xml:id="AKeEΤ">ibertae</ex></expan></w> <g ref="#interpunct" xml:id="AKeEε">·</g> <name xml:id="AKeEο"><w n="55">Donatae</w></name></persName> <g ref="#interpunct" xml:id="AKeFA">·</g> <w xml:id="AKeFK" n="60"><expan xml:id="AKeFU"><abbr xml:id="AKeFe">m</abbr><ex cert="low" xml:id="AKeFo">erentibus</ex></expan></w>
+                </ab>
+            </div>
+            <div type="edition" subtype="simple-lemmatized">
+                <ab>
+                    <w n="5" lemma="Caius">Caio</w>
+                    <w n="10" lemma="Virius">Virio</w>
+                    <w n="15" lemma="Caius">Cai</w>
+                    <w n="20" lemma="filius">filio</w>
+                    <w n="25" lemma="Claudia">Claudia</w>
+                    <w n="30" lemma="Maximus">Maximo</w>
+                    <w n="35" lemma="haruspex">haruspici</w>
+                    <w n="40" lemma="Clodia">Clodiae</w>
+                    <w n="45" lemma="Marcus">Marci</w>
+                    <w n="50" lemma="liberta">libertae</w>
+                    <w n="55" lemma="Donata">Donatae</w>
+                    <w n="60" lemma="mereor">merentibus</w>
                 </ab>
             </div>
             <div type="apparatus">
                 <listApp>
-                    <app><note>Text from autopsy</note></app>
+                    <app>
+                        <note>Text from autopsy</note>
+                    </app>
                     <app loc="3">
                         <note>Mommsen: 'm(erentibus) potius quam m(aritae)'</note>
                     </app>
                 </listApp>
             </div>
-            <div type="translation" xml:lang="en" resp="#TA"> 
+            <div type="translation" xml:lang="en" resp="#TA">
                 <p>To Gaius Virius Maximus, son of Gaius, of the Claudia tribe, haruspex, (and) to Clodia Donata, freedwoman of Marcus, well-deserving.</p>
             </div>
             <div type="commentary">
-                <p></p>
+                <p/>
             </div>
             <div type="bibliography">
                 <listBibl type="edition">
@@ -258,12 +281,12 @@
                             <ref target="http://arachne.uni-koeln.de/item/buchseite/650797">10.7355</ref>
                         </citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/GQN8UZSI"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10000589">https://biblio.inscriptiones.org/epig10000589</ref>
+                        <ref target="https://biblio.inscriptiones.org/epig10000589">https://biblio.inscriptiones.org/epig10000589</ref>
                     </bibl>
                     <bibl type="corpus" n="ILMusTermini">
                         <citedRange>21</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/JCV85C79"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002137">https://biblio.inscriptiones.org/epig10002137</ref>
+                        <ref target="https://biblio.inscriptiones.org/epig10002137">https://biblio.inscriptiones.org/epig10002137</ref>
                     </bibl>
                     <bibl>
                         <author>Rizzo</author>
@@ -273,7 +296,9 @@
                         <ref target="https://biblio.inscriptiones.org/epig10001640">https://biblio.inscriptiones.org/epig10001640</ref>
                     </bibl>
                 </listBibl>
-                <listBibl type="discussion"><bibl/></listBibl>
+                <listBibl type="discussion">
+                    <bibl/>
+                </listBibl>
             </div>
         </body>
     </text>

--- a/inscriptions/ISic000106.xml
+++ b/inscriptions/ISic000106.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../schematron/ircyr-checking.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">
@@ -9,7 +9,9 @@
                 <editor ref="#JP">Jonathan Prag</editor>
                 <principal ref="#JP">Jonathan Prag</principal>
                 <funder>John Fell OUP Research Fund</funder>
-	   <funder><ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref></funder>
+                <funder>
+                    <ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref>
+                </funder>
                 <respStmt>
                     <name xml:id="JP" ref="http://orcid.org/0000-0003-3819-8537">Jonathan Prag</name>
                     <resp>original data collection and editing</resp>
@@ -34,11 +36,11 @@
                     <name xml:id="TA" ref="https://orcid.org/0000-0001-8417-7089">Tuuli Ahlholm</name>
                     <resp>EpiDoc editing</resp>
                 </respStmt>
-	    <respStmt>
-     	       <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
-     	       <resp>standardisation of template and tidying up encoding</resp>
- 	   </respStmt>
-	    <respStmt>
+                <respStmt>
+                    <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
+                    <resp>standardisation of template and tidying up encoding</resp>
+                </respStmt>
+                <respStmt>
                     <name xml:id="system">system</name>
                     <resp>automated or batch processes</resp>
                 </respStmt>
@@ -82,7 +84,8 @@
                     <physDesc>
                         <objectDesc>
                             <supportDesc>
-                                <support><p>Fragment of a yellow/brown limestone plaque. Broken on all sides and heavily abraded on surface. The second line is abraded and partially destroyed by later reuse: an oval slot/door jamb or similar was carved into stone. The back is flat, but for a teardrop shaped recess in centre of stone.</p>
+                                <support>
+                                    <p>Fragment of a yellow/brown limestone plaque. Broken on all sides and heavily abraded on surface. The second line is abraded and partially destroyed by later reuse: an oval slot/door jamb or similar was carved into stone. The back is flat, but for a teardrop shaped recess in centre of stone.</p>
                                     <material ana="#material.stone.limestone" ref="http://www.eagle-network.eu/voc/material/lod/66.html">limestone</material>
                                     <objectType ana="#object.plaque" ref="http://www.eagle-network.eu/voc/objtyp/lod/259.html">plaque</objectType>
                                     <dimensions>
@@ -92,16 +95,18 @@
                                     </dimensions>
                                 </support>
                                 <condition/>
-		    </supportDesc>
+                            </supportDesc>
                             <layoutDesc>
-                                <layout><p>Three lines of fragmentary Latin text. Triangular interpunct in line 2.</p>
+                                <layout>
+                                    <p>Three lines of fragmentary Latin text. Triangular interpunct in line 2.</p>
                                     <rs ana="#execution.chiselled" ref="http://www.eagle-network.eu/voc/writing/lod/1">chiselled</rs>
-                                	<damage/>
-			</layout>
+                                    <damage/>
+                                </layout>
                             </layoutDesc>
                         </objectDesc>
                         <handDesc>
-                            <handNote><p>Letters are tall, thin and crowded together, but nonetheless well-formed, with clean, straight serifs.</p>
+                            <handNote>
+                                <p>Letters are tall, thin and crowded together, but nonetheless well-formed, with clean, straight serifs.</p>
                                 <locus from="line1" to="line1">Line 1</locus>
                                 <dimensions type="letterHeight">
                                     <height unit="mm">tallest letter 36 (but no letter complete)</height>
@@ -124,10 +129,10 @@
                     <history>
                         <origin>
                             <origPlace>
-                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462513" cert="low">Thermae Himeraeae</placeName>		
+                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462513" cert="low">Thermae Himeraeae</placeName>
                                 <placeName type="modern" ref="http://sws.geonames.org/6539140">Termini Imerese</placeName>
-                            	<geo>37.98365, 13.69555</geo>
-		</origPlace>
+                                <geo>37.98365, 13.69555</geo>
+                            </origPlace>
                             <origDate datingMethod="#julian" notBefore-custom="0001" notAfter-custom="0300" cert="low">Imperial</origDate>
                         </origin>
                         <provenance type="found" subtype="discovered">The place, date, and circumstances of the discovery are unknown, but the fragment is assumed to come from Termini Imerese</provenance>
@@ -138,18 +143,18 @@
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
-             <p>Encoded following the latest EpiDoc guidelines</p>
-             <xi:include href="../alists/ISicily-taxonomies.xml">
-                 <xi:fallback>
-                     <p>Taxonomies for ISicily controlled values</p>
-                 </xi:fallback>
-             </xi:include>
-	  <xi:include href="../alists/charDecl.xml">
-	     <xi:fallback>
-	       <p>ISicily glyphs authority list</p>
-	     </xi:fallback>
-	   </xi:include>
-         </encodingDesc>
+            <p>Encoded following the latest EpiDoc guidelines</p>
+            <xi:include href="../alists/ISicily-taxonomies.xml">
+                <xi:fallback>
+                    <p>Taxonomies for ISicily controlled values</p>
+                </xi:fallback>
+            </xi:include>
+            <xi:include href="../alists/charDecl.xml">
+                <xi:fallback>
+                    <p>ISicily glyphs authority list</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
             <calendarDesc>
                 <calendar xml:id="julian">
@@ -179,15 +184,15 @@
             <listChange>
                 <change when="2016-12-03" who="#JCu">James Cummings autogenerated EpiDoc output from database</change>
                 <change when="2018-10-16" who="#TA">Tuuli Ahlholm cleaned up the autogenerated text and added an apparatus</change>
-            	   <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
-            	   <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
-            	<change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
-		<change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
-	    <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
-            	<change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
+                <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
+                <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
+                <change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
+                <change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
+                <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
+                <change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
                 <change when="2023-08-23" who="#JP">Jonathan Prag added image</change>
                 <change when="2023-12-05" who="#AA">edition on basis of autopsy and photographs</change>
-	</listChange>
+            </listChange>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -198,7 +203,7 @@
             <graphic n="print" url="ISic000106.jpg" height="3680px" width="5520px">
                 <desc>I.Sicily with the permission of the Assessorato Regionale dei Beni Culturali e dell’Identità Siciliana - Dipartimento dei Beni Culturali e dell’Identità Siciliana</desc>
             </graphic>
-         </surface>
+        </surface>
         <surface type="rear">
             <graphic n="screen" url="ISic000106_rear_tiled.tif" height="3680px" width="5520px">
                 <desc>I.Sicily with the permission of the Assessorato Regionale dei Beni Culturali e dell’Identità Siciliana - Dipartimento dei Beni Culturali e dell’Identità Siciliana</desc>
@@ -212,20 +217,46 @@
         <body>
             <div type="edition" xml:space="preserve" xml:lang="la" resp="#TA #AA">
                 <ab>
-                    <lb n="1" xml:id="AKΙAK"/><gap reason="lost" extent="unknown" unit="character" xml:id="AKΙAU"/><w xml:id="AKΙAe"><unclear xml:id="AKΙAo">sir</unclear><supplied reason="undefined" evidence="previouseditor" xml:id="AKΙAy">e<unclear xml:id="AKΙAΙ">s</unclear></supplied></w> <gap reason="lost" extent="unknown" unit="character" xml:id="AKΙAΤ"/>
-                    <lb n="2" xml:id="AKΙAε"/><gap reason="lost" extent="unknown" unit="character" xml:id="AKΙAο"/><num atLeast="2" xml:id="AKΙBA"><unclear xml:id="AKΙBK">II</unclear></num> <g ref="#interpunct" xml:id="AKΙBU">·</g> <w xml:id="AKΙBe">m<unclear xml:id="AKΙBo">a</unclear></w> <gap reason="lost" atLeast="5" atMost="6" unit="character" xml:id="AKΙBy"/><num atLeast="11" xml:id="AKΙBΙ">XI</num> <gap reason="lost" extent="unknown" unit="character" xml:id="AKΙBΤ"/>
-                    <lb n="3" xml:id="AKΙBε"/><gap reason="lost" extent="unknown" unit="character" xml:id="AKΙBο"/><w xml:id="AKΙCA"><supplied reason="lost" xml:id="AKΙCK">impen</supplied>sa</w> <w xml:id="AKΙCU"><hi rend="ligature" xml:id="AKΙCe">pu</hi>blica</w> <w xml:id="AKΙCo"><unclear xml:id="AKΙCy">lo</unclear></w> <gap reason="lost" extent="unknown" unit="character" xml:id="AKΙCΙ"/>
+                    <lb n="1" xml:id="AKΙAK"/><gap reason="lost" extent="unknown" unit="character" xml:id="AKΙAU"/><w xml:id="AKΙAe" n="5"><unclear xml:id="AKΙAo">sir</unclear><supplied reason="undefined" evidence="previouseditor" xml:id="AKΙAy">e<unclear xml:id="AKΙAΙ">s</unclear></supplied></w> <gap reason="lost" extent="unknown" unit="character" xml:id="AKΙAΤ"/>
+                    <lb n="2" xml:id="AKΙAε"/><gap reason="lost" extent="unknown" unit="character" xml:id="AKΙAο"/><num atLeast="2" xml:id="AKΙBA"><w n="10"><unclear xml:id="AKΙBK">II</unclear></w></num> <g ref="#interpunct" xml:id="AKΙBU">·</g> <w xml:id="AKΙBe" n="15">m<unclear xml:id="AKΙBo">a</unclear></w> <gap reason="lost" atLeast="5" atMost="6" unit="character" xml:id="AKΙBy"/><num atLeast="11" xml:id="AKΙBΙ"><w n="20">XI</w></num> <gap reason="lost" extent="unknown" unit="character" xml:id="AKΙBΤ"/>
+                    <lb n="3" xml:id="AKΙBε"/><gap reason="lost" extent="unknown" unit="character" xml:id="AKΙBο"/><w xml:id="AKΙCA" n="25"><supplied reason="lost" xml:id="AKΙCK">impen</supplied>sa</w> <w xml:id="AKΙCU" n="30"><hi rend="ligature" xml:id="AKΙCe">pu</hi>blica</w> <w xml:id="AKΙCo" n="35"><unclear xml:id="AKΙCy">lo</unclear></w> <gap reason="lost" extent="unknown" unit="character" xml:id="AKΙCΙ"/>
+                </ab>
+            </div>
+            <div type="edition" subtype="simple-lemmatized">
+                <ab>
+                    <gap reason="lost" extent="unknown" unit="character"/>
+                    <w n="5" lemma="NOLEMMA">sires</w>
+                    <gap reason="lost" extent="unknown" unit="character"/>
+                    <gap reason="lost" extent="unknown" unit="character"/>
+                    <w n="10" lemma="II">II</w>
+                    <w n="15" lemma="NOLEMMA">ma</w>
+                    <gap reason="lost" atLeast="5" atMost="6" unit="character"/>
+                    <w n="20" lemma="XI">XI</w>
+                    <gap reason="lost" extent="unknown" unit="character"/>
+                    <gap reason="lost" extent="unknown" unit="character"/>
+                    <w n="25" lemma="impensa">impensa</w>
+                    <w n="30" lemma="publicus">publica</w>
+                    <w n="35" lemma="NOLEMMA">lo</w>
+                    <gap reason="lost" extent="unknown" unit="character"/>
                 </ab>
             </div>
             <div type="apparatus">
                 <listApp>
-                    <app><note>Text based on autopsy, and comparison to Mommsen (CIL)</note></app>
-                    <app loc="1"><note>Mommsen (CIL) apparently saw a more complete version of the inscription, and records SIRE S in line 1</note></app>
-                    <app loc="3"><note>PU is superimposed</note></app>
+                    <app>
+                        <note>Text based on autopsy, and comparison to Mommsen (CIL)</note>
+                    </app>
+                    <app loc="1">
+                        <note>Mommsen (CIL) apparently saw a more complete version of the inscription, and records SIRE S in line 1</note>
+                    </app>
+                    <app loc="3">
+                        <note>PU is superimposed</note>
+                    </app>
                 </listApp>
             </div>
             <div type="translation">
-                <p><!--translation(s) - add @xml:lang for 'en' or 'it' to div--></p>
+                <p>
+                    <!--translation(s) - add @xml:lang for 'en' or 'it' to div-->
+                </p>
             </div>
             <div type="commentary" resp="#AA">
                 <p>The inscription appears to allude, if we accept the restoration [impen]sa publica, to some initiative financed with public funds.</p>
@@ -237,14 +268,18 @@
                             <ref target="http://arachne.uni-koeln.de/item/buchseite/650797">10.7357</ref>
                         </citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/GQN8UZSI"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10000589">https://biblio.inscriptiones.org/epig10000589</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10000589">https://biblio.inscriptiones.org/epig10000589</ref>
+                    </bibl>
                     <bibl type="corpus" n="ILMusTermini">
                         <citedRange>24</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/JCV85C79"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002137">https://biblio.inscriptiones.org/epig10002137</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10002137">https://biblio.inscriptiones.org/epig10002137</ref>
+                    </bibl>
                     <bibl/>
                 </listBibl>
-	   <listBibl type="discussion"><bibl/></listBibl>
+                <listBibl type="discussion">
+                    <bibl/>
+                </listBibl>
             </div>
         </body>
     </text>

--- a/inscriptions/ISic000839.xml
+++ b/inscriptions/ISic000839.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../schematron/ircyr-checking.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">
@@ -9,7 +9,9 @@
                 <editor ref="#JP">Jonathan Prag</editor>
                 <principal ref="#JP">Jonathan Prag</principal>
                 <funder>John Fell OUP Research Fund</funder>
-	   <funder><ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref></funder>
+                <funder>
+                    <ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref>
+                </funder>
                 <respStmt>
                     <name xml:id="JP" ref="http://orcid.org/0000-0003-3819-8537">Jonathan Prag</name>
                     <resp>original data collection and editing</resp>
@@ -30,15 +32,15 @@
                     <name xml:id="MM">Michael Metcalfe</name>
                     <resp>museum data collection</resp>
                 </respStmt>
-	    <respStmt>
-     	       <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
-     	       <resp>standardisation of template and tidying up encoding</resp>
- 	   </respStmt>
+                <respStmt>
+                    <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
+                    <resp>standardisation of template and tidying up encoding</resp>
+                </respStmt>
                 <respStmt>
                     <name xml:id="VM" ref="https://orcid.org/0000-0002-7122-2511">Valentina Mignosa</name>
                     <resp>encoding text division and checking the edition</resp>
                 </respStmt>
-	    <respStmt>
+                <respStmt>
                     <name xml:id="system">system</name>
                     <resp>automated or batch processes</resp>
                 </respStmt>
@@ -80,25 +82,29 @@
                     <physDesc>
                         <objectDesc>
                             <supportDesc>
-                                <support><p>Described as incised on the rock face on one side of the tomb</p>
+                                <support>
+                                    <p>Described as incised on the rock face on one side of the tomb</p>
                                     <material ana="#material.stone" ref="http://www.eagle-network.eu/voc/material/lod/2.html">stone</material>
-                                    <dimensions><!--Default values and requires editing-->
+                                    <dimensions>
+                                        <!--Default values and requires editing-->
                                         <height unit="cm"/>
                                         <width unit="cm"/>
                                         <depth unit="cm"/>
                                     </dimensions>
                                 </support>
                                 <condition/>
-		    </supportDesc>
+                            </supportDesc>
                             <layoutDesc>
-                                <layout><!--Default value and requires checking-->
+                                <layout>
+                                    <!--Default value and requires checking-->
                                     <rs ana="#execution.chiselled" ref="http://www.eagle-network.eu/voc/writing/lod/1">chiselled</rs>
-                                	<damage/>
-			</layout>
+                                    <damage/>
+                                </layout>
                             </layoutDesc>
                         </objectDesc>
                         <handDesc>
-                            <handNote><!--Default value and requires editing-->
+                            <handNote>
+                                <!--Default value and requires editing-->
                                 <locus from="line1" to="line1">Line 1</locus>
                                 <dimensions type="letterHeight">
                                     <height unit="mm"/>
@@ -113,13 +119,16 @@
                     <history>
                         <origin>
                             <origPlace>
-                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462503">Syracusae</placeName>		
+                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462503">Syracusae</placeName>
                                 <placeName type="modern" ref="http://sws.geonames.org/2523083">Siracusa</placeName>
-                            	<geo>37.08415, 15.27628</geo>
-		</origPlace>
+                                <geo>37.08415, 15.27628</geo>
+                            </origPlace>
                             <origDate datingMethod="#julian" cert="low">(?)</origDate>
                         </origin>
-                        <provenance type="found" subtype="discovered" when="1804-11-05">Found by Capodieci 5 November 1804 in the 'Grotta della Spedaliere', in the area immediately above the Greek theatre<geo>37.076816, 15.274884</geo></provenance><!-- generic point above the theatre -->
+                        <provenance type="found" subtype="discovered" when="1804-11-05">
+                            Found by Capodieci 5 November 1804 in the 'Grotta della Spedaliere', in the area immediately above the Greek theatre<geo>37.076816, 15.274884</geo>
+                        </provenance>
+                        <!-- generic point above the theatre -->
                         <provenance type="not-observed" subtype="lost">Capodieci states that he gave it to the Syracuse museum, but it does not seem to have passed into the collection of the Museo Archeologico Regionale Paolo Orsi and has not been recorded since.</provenance>
                         <provenance type="observed" subtype="autopsied">None</provenance>
                         <acquisition/>
@@ -128,18 +137,18 @@
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
-             <p>Encoded following the latest EpiDoc guidelines</p>
-             <xi:include href="../alists/ISicily-taxonomies.xml">
-                 <xi:fallback>
-                     <p>Taxonomies for ISicily controlled values</p>
-                 </xi:fallback>
-             </xi:include>
-	  <xi:include href="../alists/charDecl.xml">
-	     <xi:fallback>
-	       <p>ISicily glyphs authority list</p>
-	     </xi:fallback>
-	   </xi:include>
-         </encodingDesc>
+            <p>Encoded following the latest EpiDoc guidelines</p>
+            <xi:include href="../alists/ISicily-taxonomies.xml">
+                <xi:fallback>
+                    <p>Taxonomies for ISicily controlled values</p>
+                </xi:fallback>
+            </xi:include>
+            <xi:include href="../alists/charDecl.xml">
+                <xi:fallback>
+                    <p>ISicily glyphs authority list</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
             <calendarDesc>
                 <calendar xml:id="julian">
@@ -168,15 +177,15 @@
         <revisionDesc status="draft">
             <listChange>
                 <change when="2016-12-03" who="#JCu">James Cummings autogenerated EpiDoc output from database</change>
-            	   <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
-            	   <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
-                            <change when="2020-11-03" who="#VM">Valentina Mignosa encoded text division, cleaned up the autogenerated text and checked the edition</change>
-            	<change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
-		<change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
-	    <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
-            	<change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
+                <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
+                <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
+                <change when="2020-11-03" who="#VM">Valentina Mignosa encoded text division, cleaned up the autogenerated text and checked the edition</change>
+                <change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
+                <change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
+                <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
+                <change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
                 <change when="2021-08-04" who="#JP">Jonathan Prag amended provenance and repository data</change>
-	</listChange>
+            </listChange>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -187,16 +196,28 @@
             <graphic n="print" url="ISic000839.jpg" height="3680px" width="5520px">
                 <desc>I.Sicily with the permission of the Assessorato Regionale dei Beni Culturali e dell’Identità Siciliana - Dipartimento dei Beni Culturali e dell’Identità Siciliana</desc>
             </graphic>
-         </surface>
+        </surface>
     </facsimile>
     <text>
         <body>
             <div type="edition" xml:space="preserve" xml:lang="grc" resp="#VM">
                 <ab>
-                    <lb n="1"/>Ἀτηδία <orig>ΠΟ<unclear>Λ</unclear>Π</orig><gap reason="lost" extent="unknown" unit="character"/>
-                    <lb n="2"/>ἄ<supplied reason="omitted">μ</supplied>εν<supplied reason="omitted">π</supplied>το<supplied reason="omitted">ς</supplied> <orig>ΟΥ</orig> <gap reason="lost" extent="unknown" unit="character"/> 
+                    <lb n="1"/><w n="5">Ἀτηδία</w> <orig n="10">ΠΟ<unclear>Λ</unclear>Π</orig><gap reason="lost" extent="unknown" unit="character"/>
+                    <lb n="2"/><w n="15">ἄ<supplied reason="omitted">μ</supplied>εν<supplied reason="omitted">π</supplied>το<supplied reason="omitted">ς</supplied></w> <orig n="20">ΟΥ</orig><gap reason="lost" extent="unknown" unit="character"/>
                     <lb n="2a"/><gap reason="lost" extent="1" unit="line"/>
                     <lb n="2b"/><gap reason="lost" extent="1" unit="line"/>
+                </ab>
+            </div>
+            <div type="edition" subtype="simple-lemmatized">
+                <ab>
+                    <w n="5" lemma="Ἀτηδία">Ἀτηδία</w>
+                    <orig n="10">ΠΟΛΠ</orig>
+                    <gap reason="lost" extent="unknown" unit="character"/>
+                    <w n="15" lemma="ἄμεμπτος">ἄμενπτος</w>
+                    <orig n="20">ΟΥ</orig>
+                    <gap reason="lost" extent="unknown" unit="character"/>
+                    <gap reason="lost" extent="1" unit="line"/>
+                    <gap reason="lost" extent="1" unit="line"/>
                 </ab>
             </div>
             <div type="apparatus">
@@ -207,11 +228,15 @@
                 </listApp>
             </div>
             <div type="translation">
-                <p><!--translation(s) - add @xml:lang for 'en' or 'it' to div--></p>
+                <p>
+                    <!--translation(s) - add @xml:lang for 'en' or 'it' to div-->
+                </p>
             </div>
             <div type="commentary">
-                <p><!--commented out pending revision-->
-                    <!--Atedia? v.frag.--></p>
+                <p>
+                    <!--commented out pending revision-->
+                    <!--Atedia? v.frag.-->
+                </p>
             </div>
             <div type="bibliography">
                 <listBibl type="edition">
@@ -220,15 +245,19 @@
                         <date>1813</date>
                         <citedRange>vol. 2, p. 127</citedRange>
                         <ptr target="http://zotero.org/groups/382445/items/4A4U5FEA"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002092">https://biblio.inscriptiones.org/epig10002092</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10002092">https://biblio.inscriptiones.org/epig10002092</ref>
+                    </bibl>
                     <bibl type="corpus" n="IG">
                         <citedRange>
                             <ref target="https://clio.columbia.edu/catalog/6873760">14.0022</ref>
                         </citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/Q2SBPG9F"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001072">https://biblio.inscriptiones.org/epig10001072</ref></bibl>
-                    </listBibl>
-	   <listBibl type="discussion"><bibl/></listBibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001072">https://biblio.inscriptiones.org/epig10001072</ref>
+                    </bibl>
+                </listBibl>
+                <listBibl type="discussion">
+                    <bibl/>
+                </listBibl>
             </div>
         </body>
     </text>

--- a/inscriptions/ISic000840.xml
+++ b/inscriptions/ISic000840.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../schematron/ircyr-checking.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">
@@ -9,7 +9,9 @@
                 <editor ref="#JP">Jonathan Prag</editor>
                 <principal ref="#JP">Jonathan Prag</principal>
                 <funder>John Fell OUP Research Fund</funder>
-	   <funder><ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref></funder>
+                <funder>
+                    <ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref>
+                </funder>
                 <respStmt>
                     <name xml:id="JP" ref="http://orcid.org/0000-0003-3819-8537">Jonathan Prag</name>
                     <resp>original data collection and editing</resp>
@@ -30,15 +32,15 @@
                     <name xml:id="MM">Michael Metcalfe</name>
                     <resp>museum data collection</resp>
                 </respStmt>
-	    <respStmt>
-     	       <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
-     	       <resp>standardisation of template and tidying up encoding</resp>
- 	   </respStmt>
+                <respStmt>
+                    <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
+                    <resp>standardisation of template and tidying up encoding</resp>
+                </respStmt>
                 <respStmt>
                     <name xml:id="VM" ref="https://orcid.org/0000-0002-7122-2511">Valentina Mignosa</name>
                     <resp>encoding text division and checking the edition</resp>
                 </respStmt>
-	    <respStmt>
+                <respStmt>
                     <name xml:id="system">system</name>
                     <resp>automated or batch processes</resp>
                 </respStmt>
@@ -61,11 +63,14 @@
             </publicationStmt>
             <sourceDesc>
                 <msDesc>
-                    <msIdentifier><!--Default country and region-->
+                    <msIdentifier>
+                        <!--Default country and region-->
                         <country>Italy</country>
                         <region>Sicily</region>
                         <settlement>Siracusa</settlement>
-                        <repository><!--Add Repository Here--></repository>
+                        <repository>
+                            <!--Add Repository Here-->
+                        </repository>
                         <!--No inventory number found-->
                         <!--Adding location for old id numbers if available-->
                         <altIdentifier>
@@ -82,23 +87,26 @@
                             <supportDesc>
                                 <support>
                                     <material ana="#material.stone" ref="http://www.eagle-network.eu/voc/material/lod/2.html">stone</material>
-                                    <dimensions><!--Default values and requires editing-->
+                                    <dimensions>
+                                        <!--Default values and requires editing-->
                                         <height unit="cm"/>
                                         <width unit="cm"/>
                                         <depth unit="cm"/>
                                     </dimensions>
                                 </support>
                                 <condition/>
-		    </supportDesc>
+                            </supportDesc>
                             <layoutDesc>
-                                <layout><!--Default value and requires checking-->
+                                <layout>
+                                    <!--Default value and requires checking-->
                                     <rs ana="#execution.chiselled" ref="http://www.eagle-network.eu/voc/writing/lod/1">chiselled</rs>
-                                	<damage/>
-			</layout>
+                                    <damage/>
+                                </layout>
                             </layoutDesc>
                         </objectDesc>
                         <handDesc>
-                            <handNote><!--Default value and requires editing-->
+                            <handNote>
+                                <!--Default value and requires editing-->
                                 <locus from="line1" to="line1">Line 1</locus>
                                 <dimensions type="letterHeight">
                                     <height unit="mm"/>
@@ -113,10 +121,10 @@
                     <history>
                         <origin>
                             <origPlace>
-                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462503">Syracusae</placeName>		
+                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462503">Syracusae</placeName>
                                 <placeName type="modern" ref="http://sws.geonames.org/2523083">Siracusa</placeName>
-                            	<geo>37.08415, 15.27628</geo>
-		</origPlace>
+                                <geo>37.08415, 15.27628</geo>
+                            </origPlace>
                             <origDate datingMethod="#julian" notBefore-custom="0001" notAfter-custom="0400">Th.K. heading; age at
                                 death (?)</origDate>
                         </origin>
@@ -128,18 +136,18 @@
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
-             <p>Encoded following the latest EpiDoc guidelines</p>
-             <xi:include href="../alists/ISicily-taxonomies.xml">
-                 <xi:fallback>
-                     <p>Taxonomies for ISicily controlled values</p>
-                 </xi:fallback>
-             </xi:include>
-	  <xi:include href="../alists/charDecl.xml">
-	     <xi:fallback>
-	       <p>ISicily glyphs authority list</p>
-	     </xi:fallback>
-	   </xi:include>
-         </encodingDesc>
+            <p>Encoded following the latest EpiDoc guidelines</p>
+            <xi:include href="../alists/ISicily-taxonomies.xml">
+                <xi:fallback>
+                    <p>Taxonomies for ISicily controlled values</p>
+                </xi:fallback>
+            </xi:include>
+            <xi:include href="../alists/charDecl.xml">
+                <xi:fallback>
+                    <p>ISicily glyphs authority list</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
             <calendarDesc>
                 <calendar xml:id="julian">
@@ -168,14 +176,14 @@
         <revisionDesc status="draft">
             <listChange>
                 <change when="2016-12-03" who="#JCu">James Cummings autogenerated EpiDoc output from database</change>
-            	   <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
-            	   <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
-                            <change when="2020-11-03" who="#VM">Valentina Mignosa encoded text division, cleaned up the autogenerated text and checked the edition</change>
-            	<change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
-		<change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
-	    <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
-            	<change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
-	</listChange>
+                <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
+                <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
+                <change when="2020-11-03" who="#VM">Valentina Mignosa encoded text division, cleaned up the autogenerated text and checked the edition</change>
+                <change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
+                <change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
+                <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
+                <change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
+            </listChange>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -186,19 +194,34 @@
             <graphic n="print" url="ISic000840.jpg" height="3680px" width="5520px">
                 <desc>I.Sicily with the permission of the Assessorato Regionale dei Beni Culturali e dell’Identità Siciliana - Dipartimento dei Beni Culturali e dell’Identità Siciliana</desc>
             </graphic>
-         </surface>
+        </surface>
     </facsimile>
     <text>
         <body>
             <div type="edition" xml:space="preserve" xml:lang="grc" resp="#VM">
                 <ab>
-                    <lb n="1"/><expan><abbr>Θ</abbr><ex>εοῖς</ex></expan> <expan><abbr>Κ</abbr><ex>αταχθονίοις</ex></expan>
-                    <lb n="2"/>Ἀφροδισιὰς
-                    <lb n="3"/>Διονυσίου
-                    <lb n="4"/>χαῖ<supplied reason="lost">ρε</supplied> Φιλίστ<supplied reason="lost">η</supplied>
-                    <lb n="5"/>μήτηρ <supplied reason="lost">ἐποίησε</supplied>
-                    <lb n="6"/>ζησ<supplied reason="omitted">ά</supplied>σ<supplied reason="lost">ῃ</supplied><gap reason="lost" extent="unknown" unit="character"/>
+                    <lb n="1"/><w n="5"><expan><abbr>Θ</abbr><ex>εοῖς</ex></expan></w> <w n="10"><expan><abbr>Κ</abbr><ex>αταχθονίοις</ex></expan></w>
+                    <lb n="2"/><w n="15">Ἀφροδισιὰς</w>
+                    <lb n="3"/><w n="20">Διονυσίου</w>
+                    <lb n="4"/><w n="25">χαῖ<supplied reason="lost">ρε</supplied></w> <w n="30">Φιλίστ<supplied reason="lost">η</supplied></w>
+                    <lb n="5"/><w n="35">μήτηρ</w> <w n="40"><supplied reason="lost">ἐποίησε</supplied></w>
+                    <lb n="6"/><w n="45">ζησ<supplied reason="omitted">ά</supplied>σ<supplied reason="lost">ῃ</supplied></w> <gap reason="lost" extent="unknown" unit="character"/>
                     <lb n="7"/><gap reason="lost" extent="1" unit="line"/>
+                </ab>
+            </div>
+            <div type="edition" subtype="simple-lemmatized">
+                <ab>
+                    <w n="5" lemma="θεός">Θεοῖς</w>
+                    <w n="10" lemma="καταχθόνιος">Καταχθονίοις</w>
+                    <w n="15" lemma="Ἀφροδισιάς">Ἀφροδισιὰς</w>
+                    <w n="20" lemma="Διονύσιος">Διονυσίου</w>
+                    <w n="25" lemma="χαίρω">χαῖρε</w>
+                    <w n="30" lemma="Φιλίστη">Φιλίστη</w>
+                    <w n="35" lemma="μήτηρ">μήτηρ</w>
+                    <w n="40" lemma="ποιέω">ἐποίησε</w>
+                    <w n="45" lemma="ζάω">ζησάσῃ</w>
+                    <gap reason="lost" extent="unknown" unit="character"/>
+                    <gap reason="lost" extent="1" unit="line"/>
                 </ab>
             </div>
             <div type="apparatus">
@@ -209,11 +232,15 @@
                 </listApp>
             </div>
             <div type="translation">
-                <p><!--translation(s) - add @xml:lang for 'en' or 'it' to div--></p>
+                <p>
+                    <!--translation(s) - add @xml:lang for 'en' or 'it' to div-->
+                </p>
             </div>
             <div type="commentary">
-                <p><!--commented out pending revision-->
-                    <!--Aphrodisias son of Dionysios; Philiste, mother... Th.K. for D.M. heading.--></p>
+                <p>
+                    <!--commented out pending revision-->
+                    <!--Aphrodisias son of Dionysios; Philiste, mother... Th.K. for D.M. heading.-->
+                </p>
             </div>
             <div type="bibliography">
                 <listBibl type="edition">
@@ -222,13 +249,17 @@
                             <ref target="https://clio.columbia.edu/catalog/6873760">14.0023</ref>
                         </citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/Q2SBPG9F"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001072">https://biblio.inscriptiones.org/epig10001072</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001072">https://biblio.inscriptiones.org/epig10001072</ref>
+                    </bibl>
                     <bibl type="corpus" n="CIG">
                         <citedRange>3.5395</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/HTUDQBXS"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001252">https://biblio.inscriptiones.org/epig10001252</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001252">https://biblio.inscriptiones.org/epig10001252</ref>
+                    </bibl>
                 </listBibl>
-	   <listBibl type="discussion"><bibl/></listBibl>
+                <listBibl type="discussion">
+                    <bibl/>
+                </listBibl>
             </div>
         </body>
     </text>

--- a/inscriptions/ISic000847.xml
+++ b/inscriptions/ISic000847.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../schematron/ircyr-checking.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">
@@ -9,7 +9,9 @@
                 <editor ref="#JP">Jonathan Prag</editor>
                 <principal ref="#JP">Jonathan Prag</principal>
                 <funder>John Fell OUP Research Fund</funder>
-	   <funder><ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref></funder>
+                <funder>
+                    <ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref>
+                </funder>
                 <respStmt>
                     <name xml:id="JP" ref="http://orcid.org/0000-0003-3819-8537">Jonathan Prag</name>
                     <resp>original data collection and editing</resp>
@@ -30,15 +32,15 @@
                     <name xml:id="MM">Michael Metcalfe</name>
                     <resp>museum data collection</resp>
                 </respStmt>
-	    <respStmt>
-     	       <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
-     	       <resp>standardisation of template and tidying up encoding</resp>
- 	   </respStmt>
+                <respStmt>
+                    <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
+                    <resp>standardisation of template and tidying up encoding</resp>
+                </respStmt>
                 <respStmt>
                     <name xml:id="VM" ref="https://orcid.org/0000-0002-7122-2511">Valentina Mignosa</name>
                     <resp>encoding text division and checking the edition</resp>
                 </respStmt>
-	    <respStmt>
+                <respStmt>
                     <name xml:id="system">system</name>
                     <resp>automated or batch processes</resp>
                 </respStmt>
@@ -80,23 +82,26 @@
                                 <support>
                                     <material ana="#material.stone" ref="http://www.eagle-network.eu/voc/material/lod/2.html">stone</material>
                                     <objectType ana="#object.unknown" ref="http://www.eagle-network.eu/voc/objtyp/lod/2.html">unknown</objectType>
-                                    <dimensions><!--Default values and requires editing-->
+                                    <dimensions>
+                                        <!--Default values and requires editing-->
                                         <height unit="cm"/>
                                         <width unit="cm"/>
                                         <depth unit="cm"/>
                                     </dimensions>
                                 </support>
                                 <condition/>
-		    </supportDesc>
+                            </supportDesc>
                             <layoutDesc>
-                                <layout><!--Default value and requires checking-->
+                                <layout>
+                                    <!--Default value and requires checking-->
                                     <rs ana="#execution.chiselled" ref="http://www.eagle-network.eu/voc/writing/lod/1">chiselled</rs>
-                                	<damage/>
-			</layout>
+                                    <damage/>
+                                </layout>
                             </layoutDesc>
                         </objectDesc>
                         <handDesc>
-                            <handNote><!--Default value and requires editing-->
+                            <handNote>
+                                <!--Default value and requires editing-->
                                 <locus from="line1" to="line1">Line 1</locus>
                                 <dimensions type="letterHeight">
                                     <height unit="mm"/>
@@ -111,13 +116,16 @@
                     <history>
                         <origin>
                             <origPlace>
-                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462503">Syracusae</placeName>		
+                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462503">Syracusae</placeName>
                                 <placeName type="modern" ref="http://sws.geonames.org/2523083">Siracusa</placeName>
-                            	<geo>37.08415, 15.27628</geo>
-		</origPlace>
+                                <geo>37.08415, 15.27628</geo>
+                            </origPlace>
                             <origDate datingMethod="#julian" notBefore-custom="0100" notAfter-custom="0400">Imperial</origDate>
                         </origin>
-                        <provenance type="found" subtype="discovered" when="1812-12">Found in December 1812 by Capodieci, alongside the road leading to the convent of the Cappuccini<geo>37.078255, 15.295179</geo></provenance><!-- location of the convent-->
+                        <provenance type="found" subtype="discovered" when="1812-12">
+                            Found in December 1812 by Capodieci, alongside the road leading to the convent of the Cappuccini<geo>37.078255, 15.295179</geo>
+                        </provenance>
+                        <!-- location of the convent-->
                         <provenance type="not-observed" subtype="lost">Although donated to the Syracuse museum in 1812 by Capodieci, it does not seem to have been seen since it was observed there by Thorlacius in the 19th cent.</provenance>
                         <provenance type="observed" subtype="autopsied">None</provenance>
                         <acquisition/>
@@ -126,18 +134,18 @@
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
-             <p>Encoded following the latest EpiDoc guidelines</p>
-             <xi:include href="../alists/ISicily-taxonomies.xml">
-                 <xi:fallback>
-                     <p>Taxonomies for ISicily controlled values</p>
-                 </xi:fallback>
-             </xi:include>
-	  <xi:include href="../alists/charDecl.xml">
-	     <xi:fallback>
-	       <p>ISicily glyphs authority list</p>
-	     </xi:fallback>
-	   </xi:include>
-         </encodingDesc>
+            <p>Encoded following the latest EpiDoc guidelines</p>
+            <xi:include href="../alists/ISicily-taxonomies.xml">
+                <xi:fallback>
+                    <p>Taxonomies for ISicily controlled values</p>
+                </xi:fallback>
+            </xi:include>
+            <xi:include href="../alists/charDecl.xml">
+                <xi:fallback>
+                    <p>ISicily glyphs authority list</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
             <calendarDesc>
                 <calendar xml:id="julian">
@@ -166,15 +174,15 @@
         <revisionDesc status="draft">
             <listChange>
                 <change when="2016-12-03" who="#JCu">James Cummings autogenerated EpiDoc output from database</change>
-            	   <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
-            	   <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
-                            <change when="2020-11-03" who="#VM">Valentina Mignosa encoded text division, cleaned up the autogenerated text and checked the edition</change>
-            	<change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
-		<change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
-	    <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
-            	<change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
+                <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
+                <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
+                <change when="2020-11-03" who="#VM">Valentina Mignosa encoded text division, cleaned up the autogenerated text and checked the edition</change>
+                <change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
+                <change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
+                <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
+                <change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
                 <change when="2021-08-04" who="#JP">Jonathan Prag amended repository and provenance data</change>
-	</listChange>
+            </listChange>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -185,16 +193,29 @@
             <graphic n="print" url="ISic000847.jpg" height="3680px" width="5520px">
                 <desc>I.Sicily with the permission of the Assessorato Regionale dei Beni Culturali e dell’Identità Siciliana - Dipartimento dei Beni Culturali e dell’Identità Siciliana</desc>
             </graphic>
-         </surface>
+        </surface>
     </facsimile>
     <text>
         <body>
             <div type="edition" xml:space="preserve" xml:lang="grc" resp="#VM">
                 <ab>
-                    <lb n="1"/>Θεοῖς <g ref="#interpunct">·</g> Χθονίοις
-                    <lb n="2"/>Ζώη χ<hi rend="ligature">ρη</hi>σ<hi rend="ligature">τὴ</hi> καὶ
-                    <lb n="3"/>ἄμεμπτος <g ref="#interpunct">·</g> ἔζησεν
-                    <lb n="4"/>ἔτη <g ref="#interpunct">·</g> <num value="22">κ <g ref="#interpunct">·</g> β</num> <g ref="#interpunct">·</g>
+                    <lb n="1"/><w n="5">Θεοῖς</w> <g ref="#interpunct">·</g> <w n="10">Χθονίοις</w>
+                    <lb n="2"/><w n="15">Ζώη</w> <w n="20">χ<hi rend="ligature">ρη</hi>σ<hi rend="ligature">τὴ</hi></w> <w n="25">καὶ</w>
+                    <lb n="3"/><w n="30">ἄμεμπτος</w> <g ref="#interpunct">·</g> <w n="35">ἔζησεν</w>
+                    <lb n="4"/><w n="40">ἔτη</w> <g ref="#interpunct">·</g> <num value="22"><w n="45">κ <g ref="#interpunct">·</g>β</w></num> <g ref="#interpunct">·</g>
+                </ab>
+            </div>
+            <div type="edition" subtype="simple-lemmatized">
+                <ab>
+                    <w n="5" lemma="θεός">Θεοῖς</w>
+                    <w n="10" lemma="χθόνιος">Χθονίοις</w>
+                    <w n="15" lemma="Ζώη">Ζώη</w>
+                    <w n="20" lemma="χρηστός">χρηστὴ</w>
+                    <w n="25" lemma="καί">καὶ</w>
+                    <w n="30" lemma="ἄμεμπτος">ἄμεμπτος</w>
+                    <w n="35" lemma="ζάω">ἔζησεν</w>
+                    <w n="40" lemma="ἔτος">ἔτη</w>
+                    <w n="45" lemma="κβ">κβ</w>
                 </ab>
             </div>
             <div type="apparatus">
@@ -205,11 +226,15 @@
                 </listApp>
             </div>
             <div type="translation">
-                <p><!--translation(s) - add @xml:lang for 'en' or 'it' to div--></p>
+                <p>
+                    <!--translation(s) - add @xml:lang for 'en' or 'it' to div-->
+                </p>
             </div>
             <div type="commentary">
-                <p><!--commented out pending revision-->
-                    <!--Zoe;Theois Chthonois in full; chrestos kai amemptos; age in years.--></p>
+                <p>
+                    <!--commented out pending revision-->
+                    <!--Zoe;Theois Chthonois in full; chrestos kai amemptos; age in years.-->
+                </p>
             </div>
             <div type="bibliography">
                 <listBibl type="edition">
@@ -218,19 +243,24 @@
                         <date>1813</date>
                         <citedRange>vol. 1, p. 278</citedRange>
                         <ptr target="http://zotero.org/groups/382445/items/4A4U5FEA"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002092">https://biblio.inscriptiones.org/epig10002092</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10002092">https://biblio.inscriptiones.org/epig10002092</ref>
+                    </bibl>
                     <bibl type="corpus" n="IG">
                         <citedRange>
                             <ref target="https://clio.columbia.edu/catalog/6873760">14.0030</ref>
                         </citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/Q2SBPG9F"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001072">https://biblio.inscriptiones.org/epig10001072</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001072">https://biblio.inscriptiones.org/epig10001072</ref>
+                    </bibl>
                     <bibl type="corpus" n="CIG">
                         <citedRange>3.5400</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/HTUDQBXS"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001252">https://biblio.inscriptiones.org/epig10001252</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001252">https://biblio.inscriptiones.org/epig10001252</ref>
+                    </bibl>
                 </listBibl>
-	   <listBibl type="discussion"><bibl/></listBibl>
+                <listBibl type="discussion">
+                    <bibl/>
+                </listBibl>
             </div>
         </body>
     </text>

--- a/inscriptions/ISic000848.xml
+++ b/inscriptions/ISic000848.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../schematron/ircyr-checking.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">
@@ -9,7 +9,9 @@
                 <editor ref="#JP">Jonathan Prag</editor>
                 <principal ref="#JP">Jonathan Prag</principal>
                 <funder>John Fell OUP Research Fund</funder>
-	   <funder><ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref></funder>
+                <funder>
+                    <ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref>
+                </funder>
                 <respStmt>
                     <name xml:id="JP" ref="http://orcid.org/0000-0003-3819-8537">Jonathan Prag</name>
                     <resp>original data collection and editing</resp>
@@ -30,15 +32,15 @@
                     <name xml:id="MM">Michael Metcalfe</name>
                     <resp>museum data collection</resp>
                 </respStmt>
-	    <respStmt>
-     	       <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
-     	       <resp>standardisation of template and tidying up encoding</resp>
- 	   </respStmt>
+                <respStmt>
+                    <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
+                    <resp>standardisation of template and tidying up encoding</resp>
+                </respStmt>
                 <respStmt>
                     <name xml:id="VM" ref="https://orcid.org/0000-0002-7122-2511">Valentina Mignosa</name>
                     <resp>encoding text division and checking the edition</resp>
                 </respStmt>
-	    <respStmt>
+                <respStmt>
                     <name xml:id="system">system</name>
                     <resp>automated or batch processes</resp>
                 </respStmt>
@@ -78,26 +80,31 @@
                     <physDesc>
                         <objectDesc>
                             <supportDesc>
-                                <support><p>opisthographic text, with <ref sameAs="ISic000863.xml">ISic000863</ref> on the same support</p>
+                                <support>
+                                    <p>
+                                        opisthographic text, with<ref sameAs="ISic000863.xml">ISic000863</ref>on the same support
+                                    </p>
                                     <material ana="#material.stone.marble" ref="http://www.eagle-network.eu/voc/material/lod/48.html">marble</material>
                                     <objectType ana="#object.plaque" ref="http://www.eagle-network.eu/voc/objtyp/lod/259">plaque</objectType>
-                                    <dimensions><!--orsi-->
+                                    <dimensions>
+                                        <!--orsi-->
                                         <height unit="cm">24</height>
                                         <width unit="cm">34</width>
                                         <depth unit="cm"/>
                                     </dimensions>
                                 </support>
                                 <condition/>
-		    </supportDesc>
+                            </supportDesc>
                             <layoutDesc>
                                 <layout>
                                     <rs ana="#execution.chiselled" ref="http://www.eagle-network.eu/voc/writing/lod/1">chiselled</rs>
-                                	<damage/>
-			</layout>
+                                    <damage/>
+                                </layout>
                             </layoutDesc>
                         </objectDesc>
                         <handDesc>
-                            <handNote><!--Default value and requires editing-->
+                            <handNote>
+                                <!--Default value and requires editing-->
                                 <locus from="line1" to="line1">Line 1</locus>
                                 <dimensions type="letterHeight">
                                     <height unit="mm"/>
@@ -112,33 +119,34 @@
                     <history>
                         <origin>
                             <origPlace>
-                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462503">Syracusae</placeName>		
+                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462503">Syracusae</placeName>
                                 <placeName type="modern" ref="http://sws.geonames.org/2523083">Siracusa</placeName>
-                            	<geo>37.08415, 15.27628</geo>
-		</origPlace>
+                                <geo>37.08415, 15.27628</geo>
+                            </origPlace>
                             <origDate datingMethod="#julian" notBefore-custom="0100" notAfter-custom="0400">Imperial period</origDate>
                         </origin>
                         <provenance type="found" subtype="discovered">vigna S. Giuliano</provenance>
                         <provenance type="observed">Depositi, Mag B</provenance>
-                        <provenance type="observed" subtype="autopsied" resp="#JP">2015-10-21 Prag</provenance><!-- Orsi319 -->
+                        <provenance type="observed" subtype="autopsied" resp="#JP">2015-10-21 Prag</provenance>
+                        <!-- Orsi319 -->
                         <acquisition/>
                     </history>
                 </msDesc>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
-             <p>Encoded following the latest EpiDoc guidelines</p>
-             <xi:include href="../alists/ISicily-taxonomies.xml">
-                 <xi:fallback>
-                     <p>Taxonomies for ISicily controlled values</p>
-                 </xi:fallback>
-             </xi:include>
-	  <xi:include href="../alists/charDecl.xml">
-	     <xi:fallback>
-	       <p>ISicily glyphs authority list</p>
-	     </xi:fallback>
-	   </xi:include>
-         </encodingDesc>
+            <p>Encoded following the latest EpiDoc guidelines</p>
+            <xi:include href="../alists/ISicily-taxonomies.xml">
+                <xi:fallback>
+                    <p>Taxonomies for ISicily controlled values</p>
+                </xi:fallback>
+            </xi:include>
+            <xi:include href="../alists/charDecl.xml">
+                <xi:fallback>
+                    <p>ISicily glyphs authority list</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
             <calendarDesc>
                 <calendar xml:id="julian">
@@ -167,16 +175,16 @@
         <revisionDesc status="draft">
             <listChange>
                 <change when="2016-12-03" who="#JCu">James Cummings autogenerated EpiDoc output from database</change>
-            	   <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
-            	   <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
-                            <change when="2020-11-03" who="#VM">Valentina Mignosa encoded text division, cleaned up the autogenerated text and checked the edition</change>
-            	<change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
-		<change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
-	    <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
+                <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
+                <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
+                <change when="2020-11-03" who="#VM">Valentina Mignosa encoded text division, cleaned up the autogenerated text and checked the edition</change>
+                <change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
+                <change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
+                <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
                 <change when="2021-01-12" who="#JP">Jonathan Prag checked inventory data</change>
-            	<change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
+                <change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
                 <change when="2023-08-11" who="#JP">Jonathan Prag added bibl, metadata, revised text</change>
-	</listChange>
+            </listChange>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -187,18 +195,34 @@
             <graphic n="print" url="ISic000848.jpg" height="3680px" width="5520px">
                 <desc>I.Sicily with the permission of the Assessorato Regionale dei Beni Culturali e dell’Identità Siciliana - Dipartimento dei Beni Culturali e dell’Identità Siciliana</desc>
             </graphic>
-         </surface>
+        </surface>
     </facsimile>
     <text>
         <body>
             <div type="edition" xml:space="preserve" xml:lang="grc" resp="#VM #JP">
                 <ab>
-                    <lb n="1"/><persName type="attested"><name>Ζώσιμε</name></persName> χρηστὲ καὶ
-                    <lb n="2"/>ἄμενπτε χαῖρε
-                    <lb n="3"/>ἔζησας ἔτη
-                    <lb n="4"/><g ref="#interpunct">·</g> <num value="14">ιδ</num> <g ref="#interpunct">·</g>
-                    <lb n="5"/>μῆνας <num value="5">πέντε</num>
-                    <lb n="6"/><g ref="#interpunct">·</g> <num value="1">μίαν</num> ἡμέραν <g ref="#interpunct">·</g>
+                    <lb n="1"/><persName type="attested"><name><w n="5">Ζώσιμε</w></name></persName> <w n="10">χρηστὲ</w> <w n="15">καὶ</w>
+                    <lb n="2"/><w n="20">ἄμενπτε</w> <w n="25">χαῖρε</w>
+                    <lb n="3"/><w n="30">ἔζησας</w> <w n="35">ἔτη</w>
+                    <lb n="4"/><g ref="#interpunct">·</g> <num value="14"><w n="40">ιδ</w></num> <g ref="#interpunct">·</g>
+                    <lb n="5"/><w n="45">μῆνας</w> <num value="5"><w n="50">πέντε</w></num>
+                    <lb n="6"/><g ref="#interpunct">·</g> <num value="1"><w n="55">μίαν</w></num> <w n="60">ἡμέραν</w> <g ref="#interpunct">·</g>
+                </ab>
+            </div>
+            <div type="edition" subtype="simple-lemmatized">
+                <ab>
+                    <w n="5" lemma="Ζώσιμος">Ζώσιμε</w>
+                    <w n="10" lemma="χρηστός">χρηστὲ</w>
+                    <w n="15" lemma="καί">καὶ</w>
+                    <w n="20" lemma="ἄμεμπτος">ἄμενπτε</w>
+                    <w n="25" lemma="χαίρω">χαῖρε</w>
+                    <w n="30" lemma="ζάω">ἔζησας</w>
+                    <w n="35" lemma="ἔτος">ἔτη</w>
+                    <w n="40" lemma="ιδ">ιδ</w>
+                    <w n="45" lemma="μείς">μῆνας</w>
+                    <w n="50" lemma="πέντε">πέντε</w>
+                    <w n="55" lemma="εἷς">μίαν</w>
+                    <w n="60" lemma="ἡμέρα">ἡμέραν</w>
                 </ab>
             </div>
             <div type="apparatus" resp="#JP">
@@ -212,7 +236,9 @@
                 <p>Zosimos, worthy and blameless, farewell! You lived 14 years, five months, one day.</p>
             </div>
             <div type="commentary">
-                <p>Note that IG 14.46 (<ref target="http://sicily.classics.ox.ac.uk/inscription/ISic000863">ISic000863</ref>) is on the other side of this stone</p>
+                <p>
+                    Note that IG 14.46 (<ref target="http://sicily.classics.ox.ac.uk/inscription/ISic000863">ISic000863</ref>) is on the other side of this stone
+                </p>
             </div>
             <div type="bibliography">
                 <listBibl type="edition">
@@ -221,25 +247,31 @@
                             <ref target="https://clio.columbia.edu/catalog/6873760">14.0031</ref>
                         </citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/Q2SBPG9F"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001072">https://biblio.inscriptiones.org/epig10001072</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001072">https://biblio.inscriptiones.org/epig10001072</ref>
+                    </bibl>
                     <bibl type="corpus" n="CIG">
                         <citedRange>3.5401</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/HTUDQBXS"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001252">https://biblio.inscriptiones.org/epig10001252</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001252">https://biblio.inscriptiones.org/epig10001252</ref>
+                    </bibl>
                     <bibl type="bulletin" n="NSA">
                         <author>Orsi</author>
                         <date>1893</date>
                         <citedRange>299 no. 81</citedRange>
                         <ptr target="http://zotero.org/groups/382445/items/V7HNHTAG"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001715">https://biblio.inscriptiones.org/epig10001715</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001715">https://biblio.inscriptiones.org/epig10001715</ref>
+                    </bibl>
                     <bibl>
                         <author>Orsi</author>
                         <date>2018</date>
                         <citedRange>Tacc. 2, p. 22</citedRange>
                         <ptr target="http://zotero.org/groups/382445/items/RGRSRUHK"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002617">https://biblio.inscriptiones.org/epig10002617</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10002617">https://biblio.inscriptiones.org/epig10002617</ref>
+                    </bibl>
                 </listBibl>
-	   <listBibl type="discussion"><bibl/></listBibl>
+                <listBibl type="discussion">
+                    <bibl/>
+                </listBibl>
             </div>
         </body>
     </text>

--- a/inscriptions/ISic000849.xml
+++ b/inscriptions/ISic000849.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../schematron/ircyr-checking.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">
@@ -9,7 +9,9 @@
                 <editor ref="#JP">Jonathan Prag</editor>
                 <principal ref="#JP">Jonathan Prag</principal>
                 <funder>John Fell OUP Research Fund</funder>
-	   <funder><ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref></funder>
+                <funder>
+                    <ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref>
+                </funder>
                 <respStmt>
                     <name xml:id="JP" ref="http://orcid.org/0000-0003-3819-8537">Jonathan Prag</name>
                     <resp>original data collection and editing</resp>
@@ -30,15 +32,15 @@
                     <name xml:id="MM">Michael Metcalfe</name>
                     <resp>museum data collection</resp>
                 </respStmt>
-	    <respStmt>
-     	       <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
-     	       <resp>standardisation of template and tidying up encoding</resp>
- 	   </respStmt>
+                <respStmt>
+                    <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
+                    <resp>standardisation of template and tidying up encoding</resp>
+                </respStmt>
                 <respStmt>
                     <name xml:id="VM" ref="https://orcid.org/0000-0002-7122-2511">Valentina Mignosa</name>
                     <resp>encoding text division and checking the edition</resp>
                 </respStmt>
-	    <respStmt>
+                <respStmt>
                     <name xml:id="system">system</name>
                     <resp>automated or batch processes</resp>
                 </respStmt>
@@ -64,7 +66,8 @@
                         <region>Sicily</region>
                         <settlement>Siracusa</settlement>
                         <repository role="museum" ref="http://sicily.classics.ox.ac.uk/museum/097">Museo Archeologico Regionale Paolo Orsi</repository>
-                        <!--No inventory number found--><!-- checked against initial inventory entries (1-223) and not in autopsy material up to 2018 -->
+                        <!--No inventory number found-->
+                        <!-- checked against initial inventory entries (1-223) and not in autopsy material up to 2018 -->
                         <!--Adding location for old id numbers if available-->
                         <altIdentifier>
                             <settlement/>
@@ -81,23 +84,25 @@
                                 <support>
                                     <material ana="#material.stone" ref="http://www.eagle-network.eu/voc/material/lod/2.html">stone</material>
                                     <objectType ana="#object.unknown" ref="http://www.eagle-network.eu/voc/objtyp/lod/2.html">unknown</objectType>
-                                    <dimensions><!--Default values and requires editing-->
+                                    <dimensions>
+                                        <!--Default values and requires editing-->
                                         <height unit="cm"/>
                                         <width unit="cm"/>
                                         <depth unit="cm"/>
                                     </dimensions>
                                 </support>
                                 <condition/>
-		    </supportDesc>
+                            </supportDesc>
                             <layoutDesc>
                                 <layout>
                                     <rs ana="#execution.chiselled" ref="http://www.eagle-network.eu/voc/writing/lod/1">chiselled</rs>
-                                	<damage/>
-			</layout>
+                                    <damage/>
+                                </layout>
                             </layoutDesc>
                         </objectDesc>
                         <handDesc>
-                            <handNote><!--Default value and requires editing-->
+                            <handNote>
+                                <!--Default value and requires editing-->
                                 <locus from="line1" to="line1">Line 1</locus>
                                 <dimensions type="letterHeight">
                                     <height unit="mm"/>
@@ -112,10 +117,10 @@
                     <history>
                         <origin>
                             <origPlace>
-                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462503">Syracusae</placeName>		
+                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462503">Syracusae</placeName>
                                 <placeName type="modern" ref="http://sws.geonames.org/2523083">Siracusa</placeName>
-                            	<geo>37.08415, 15.27628</geo>
-		</origPlace>
+                                <geo>37.08415, 15.27628</geo>
+                            </origPlace>
                             <origDate datingMethod="#julian" cert="low">(?)</origDate>
                         </origin>
                         <provenance type="found">Original discovery not recorded</provenance>
@@ -127,18 +132,18 @@
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
-             <p>Encoded following the latest EpiDoc guidelines</p>
-             <xi:include href="../alists/ISicily-taxonomies.xml">
-                 <xi:fallback>
-                     <p>Taxonomies for ISicily controlled values</p>
-                 </xi:fallback>
-             </xi:include>
-	  <xi:include href="../alists/charDecl.xml">
-	     <xi:fallback>
-	       <p>ISicily glyphs authority list</p>
-	     </xi:fallback>
-	   </xi:include>
-         </encodingDesc>
+            <p>Encoded following the latest EpiDoc guidelines</p>
+            <xi:include href="../alists/ISicily-taxonomies.xml">
+                <xi:fallback>
+                    <p>Taxonomies for ISicily controlled values</p>
+                </xi:fallback>
+            </xi:include>
+            <xi:include href="../alists/charDecl.xml">
+                <xi:fallback>
+                    <p>ISicily glyphs authority list</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
             <calendarDesc>
                 <calendar xml:id="julian">
@@ -167,15 +172,15 @@
         <revisionDesc status="draft">
             <listChange>
                 <change when="2016-12-03" who="#JCu">James Cummings autogenerated EpiDoc output from database</change>
-            	   <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
-            	   <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
-                            <change when="2020-11-03" who="#VM">Valentina Mignosa encoded text division, cleaned up the autogenerated text and checked the edition</change>
-            	<change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
-		<change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
-	    <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
-            	<change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
+                <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
+                <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
+                <change when="2020-11-03" who="#VM">Valentina Mignosa encoded text division, cleaned up the autogenerated text and checked the edition</change>
+                <change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
+                <change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
+                <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
+                <change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
                 <change when="2021-08-04" who="#JP">Jonathan Prag amended provenance and repository data</change>
-	</listChange>
+            </listChange>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -186,14 +191,22 @@
             <graphic n="print" url="ISic000849.jpg" height="3680px" width="5520px">
                 <desc>I.Sicily with the permission of the Assessorato Regionale dei Beni Culturali e dell’Identità Siciliana - Dipartimento dei Beni Culturali e dell’Identità Siciliana</desc>
             </graphic>
-         </surface>
+        </surface>
     </facsimile>
     <text>
         <body>
             <div type="edition" xml:space="preserve" xml:lang="grc" resp="#VM">
                 <ab>
-                    <lb n="1"/><unclear>Θ</unclear>ρασεῖα
-                    <lb n="2"/><gap reason="lost" extent="unknown" unit="character"/><orig>ΑΣ</orig><gap reason="lost" extent="unknown" unit="character"/>
+                    <lb n="1"/><w n="5"><unclear>Θ</unclear>ρασεῖα</w>
+                    <lb n="2"/><gap reason="lost" extent="unknown" unit="character"/><orig n="10">ΑΣ</orig><gap reason="lost" extent="unknown" unit="character"/>
+                </ab>
+            </div>
+            <div type="edition" subtype="simple-lemmatized">
+                <ab>
+                    <w n="5" lemma="θρασύς">Θρασεῖα</w>
+                    <gap reason="lost" extent="unknown" unit="character"/>
+                    <orig n="10">ΑΣ</orig>
+                    <gap reason="lost" extent="unknown" unit="character"/>
                 </ab>
             </div>
             <div type="apparatus">
@@ -204,11 +217,15 @@
                 </listApp>
             </div>
             <div type="translation">
-                <p><!--translation(s) - add @xml:lang for 'en' or 'it' to div--></p>
+                <p>
+                    <!--translation(s) - add @xml:lang for 'en' or 'it' to div-->
+                </p>
             </div>
             <div type="commentary">
-                <p><!--commented out pending revision-->
-                    <!--Thraseia? v. frag.--></p>
+                <p>
+                    <!--commented out pending revision-->
+                    <!--Thraseia? v. frag.-->
+                </p>
             </div>
             <div type="bibliography">
                 <listBibl type="edition">
@@ -217,15 +234,19 @@
                             <ref target="https://clio.columbia.edu/catalog/6873760">14.0032</ref>
                         </citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/Q2SBPG9F"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001072">https://biblio.inscriptiones.org/epig10001072</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001072">https://biblio.inscriptiones.org/epig10001072</ref>
+                    </bibl>
                     <bibl>
                         <author>Orsi</author>
                         <date>2018</date>
                         <citedRange>Tacc. 1, p. 58</citedRange>
                         <ptr target="http://zotero.org/groups/382445/items/RGRSRUHK"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002617">https://biblio.inscriptiones.org/epig10002617</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10002617">https://biblio.inscriptiones.org/epig10002617</ref>
+                    </bibl>
                 </listBibl>
-	   <listBibl type="discussion"><bibl/></listBibl>
+                <listBibl type="discussion">
+                    <bibl/>
+                </listBibl>
             </div>
         </body>
     </text>

--- a/inscriptions/ISic000852.xml
+++ b/inscriptions/ISic000852.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../schematron/ircyr-checking.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">
@@ -9,7 +9,9 @@
                 <editor ref="#JP">Jonathan Prag</editor>
                 <principal ref="#JP">Jonathan Prag</principal>
                 <funder>John Fell OUP Research Fund</funder>
-	   <funder><ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref></funder>
+                <funder>
+                    <ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref>
+                </funder>
                 <respStmt>
                     <name xml:id="JP" ref="http://orcid.org/0000-0003-3819-8537">Jonathan Prag</name>
                     <resp>original data collection and editing</resp>
@@ -30,15 +32,15 @@
                     <name xml:id="MM">Michael Metcalfe</name>
                     <resp>museum data collection</resp>
                 </respStmt>
-	    <respStmt>
-     	       <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
-     	       <resp>standardisation of template and tidying up encoding</resp>
- 	   </respStmt>
+                <respStmt>
+                    <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
+                    <resp>standardisation of template and tidying up encoding</resp>
+                </respStmt>
                 <respStmt>
                     <name xml:id="VM" ref="https://orcid.org/0000-0002-7122-2511">Valentina Mignosa</name>
                     <resp>encoding text division and checking the edition</resp>
                 </respStmt>
-	    <respStmt>
+                <respStmt>
                     <name xml:id="system">system</name>
                     <resp>automated or batch processes</resp>
                 </respStmt>
@@ -61,11 +63,14 @@
             </publicationStmt>
             <sourceDesc>
                 <msDesc>
-                    <msIdentifier><!--Default country and region-->
+                    <msIdentifier>
+                        <!--Default country and region-->
                         <country>Italy</country>
                         <region>Sicily</region>
                         <settlement>Siracusa</settlement>
-                        <repository><!--Add Repository Here--></repository>
+                        <repository>
+                            <!--Add Repository Here-->
+                        </repository>
                         <!--No inventory number found-->
                         <!--Adding location for old id numbers if available-->
                         <altIdentifier>
@@ -82,23 +87,26 @@
                             <supportDesc>
                                 <support>
                                     <material ana="#material.stone" ref="http://www.eagle-network.eu/voc/material/lod/2.html">stone</material>
-                                    <dimensions><!--Default values and requires editing-->
+                                    <dimensions>
+                                        <!--Default values and requires editing-->
                                         <height unit="cm"/>
                                         <width unit="cm"/>
                                         <depth unit="cm"/>
                                     </dimensions>
                                 </support>
                                 <condition/>
-		    </supportDesc>
+                            </supportDesc>
                             <layoutDesc>
-                                <layout><!--Default value and requires checking-->
+                                <layout>
+                                    <!--Default value and requires checking-->
                                     <rs ana="#execution.chiselled" ref="http://www.eagle-network.eu/voc/writing/lod/1">chiselled</rs>
-                                	<damage/>
-			</layout>
+                                    <damage/>
+                                </layout>
                             </layoutDesc>
                         </objectDesc>
                         <handDesc>
-                            <handNote><!--Default value and requires editing-->
+                            <handNote>
+                                <!--Default value and requires editing-->
                                 <locus from="line1" to="line1">Line 1</locus>
                                 <dimensions type="letterHeight">
                                     <height unit="mm"/>
@@ -113,10 +121,10 @@
                     <history>
                         <origin>
                             <origPlace>
-                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462503">Syracusae</placeName>		
+                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462503">Syracusae</placeName>
                                 <placeName type="modern" ref="http://sws.geonames.org/2523083">Siracusa</placeName>
-                            	<geo>37.08415, 15.27628</geo>
-		</origPlace>
+                                <geo>37.08415, 15.27628</geo>
+                            </origPlace>
                             <origDate datingMethod="#julian" notBefore-custom="0001" notAfter-custom="0400">Th.K heading; age (?)</origDate>
                         </origin>
                         <provenance type="found">Original discovery not recorded.</provenance>
@@ -127,18 +135,18 @@
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
-             <p>Encoded following the latest EpiDoc guidelines</p>
-             <xi:include href="../alists/ISicily-taxonomies.xml">
-                 <xi:fallback>
-                     <p>Taxonomies for ISicily controlled values</p>
-                 </xi:fallback>
-             </xi:include>
-	  <xi:include href="../alists/charDecl.xml">
-	     <xi:fallback>
-	       <p>ISicily glyphs authority list</p>
-	     </xi:fallback>
-	   </xi:include>
-         </encodingDesc>
+            <p>Encoded following the latest EpiDoc guidelines</p>
+            <xi:include href="../alists/ISicily-taxonomies.xml">
+                <xi:fallback>
+                    <p>Taxonomies for ISicily controlled values</p>
+                </xi:fallback>
+            </xi:include>
+            <xi:include href="../alists/charDecl.xml">
+                <xi:fallback>
+                    <p>ISicily glyphs authority list</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
             <calendarDesc>
                 <calendar xml:id="julian">
@@ -167,14 +175,14 @@
         <revisionDesc status="draft">
             <listChange>
                 <change when="2016-12-03" who="#JCu">James Cummings autogenerated EpiDoc output from database</change>
-            	   <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
-            	   <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
-                            <change when="2020-11-03" who="#VM">Valentina Mignosa encoded text division, cleaned up the autogenerated text and checked the edition</change>
-            	<change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
-		<change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
-	    <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
-            	<change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
-	</listChange>
+                <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
+                <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
+                <change when="2020-11-03" who="#VM">Valentina Mignosa encoded text division, cleaned up the autogenerated text and checked the edition</change>
+                <change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
+                <change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
+                <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
+                <change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
+            </listChange>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -185,17 +193,30 @@
             <graphic n="print" url="ISic000852.jpg" height="3680px" width="5520px">
                 <desc>I.Sicily with the permission of the Assessorato Regionale dei Beni Culturali e dell’Identità Siciliana - Dipartimento dei Beni Culturali e dell’Identità Siciliana</desc>
             </graphic>
-         </surface>
+        </surface>
     </facsimile>
     <text>
         <body>
             <div type="edition" xml:space="preserve" xml:lang="grc" resp="#VM">
                 <ab>
-                    <lb n="1"/><expan><abbr>Θ</abbr><ex>εοῖς</ex></expan> <expan><abbr>Κ</abbr><ex>αταχθονίοις</ex></expan>
-                    <lb n="2"/><orig>ΠΙΡΟΣΙΦΙΤΟΥ</orig>
-                    <lb n="3"/>Δεξιὸς
-                    <lb n="4"/><orig>ΚΑΙΣΩΟΔ</orig><gap reason="lost" extent="unknown" unit="character"/>
-                    <lb n="5"/><expan><abbr>ἔζησ</abbr><ex>εν</ex></expan> <supplied reason="lost">ἔτη</supplied> <gap reason="lost" extent="unknown" unit="character"/>
+                    <lb n="1"/><w n="5"><expan><abbr>Θ</abbr><ex>εοῖς</ex></expan></w> <w n="10"><expan><abbr>Κ</abbr><ex>αταχθονίοις</ex></expan></w>
+                    <lb n="2"/><orig n="15">ΠΙΡΟΣΙΦΙΤΟΥ</orig>
+                    <lb n="3"/><w n="20">Δεξιὸς</w>
+                    <lb n="4"/><orig n="25">ΚΑΙΣΩΟΔ</orig><gap reason="lost" extent="unknown" unit="character"/>
+                    <lb n="5"/><w n="30"><expan><abbr>ἔζησ</abbr><ex>εν</ex></expan></w> <w n="35"><supplied reason="lost">ἔτη</supplied></w> <gap reason="lost" extent="unknown" unit="character"/>
+                </ab>
+            </div>
+            <div type="edition" subtype="simple-lemmatized">
+                <ab>
+                    <w n="5" lemma="θεός">Θεοῖς</w>
+                    <w n="10" lemma="καταχθόνιος">Καταχθονίοις</w>
+                    <orig n="15">ΠΙΡΟΣΙΦΙΤΟΥ</orig>
+                    <w n="20" lemma="Δεξιός">Δεξιὸς</w>
+                    <orig n="25">ΚΑΙΣΩΟΔ</orig>
+                    <gap reason="lost" extent="unknown" unit="character"/>
+                    <w n="30" lemma="ζάω">ἔζησεν</w>
+                    <w n="35" lemma="ἔτος">ἔτη</w>
+                    <gap reason="lost" extent="unknown" unit="character"/>
                 </ab>
             </div>
             <div type="apparatus">
@@ -206,11 +227,15 @@
                 </listApp>
             </div>
             <div type="translation">
-                <p><!--translation(s) - add @xml:lang for 'en' or 'it' to div--></p>
+                <p>
+                    <!--translation(s) - add @xml:lang for 'en' or 'it' to div-->
+                </p>
             </div>
             <div type="commentary">
-                <p><!--commented out pending revision-->
-                    <!--Text is a mess; Kaibel, l.2 : Ποστούμιος; l.3: Κλ(αυδίᾳ) Σωφ[ροσύνῃ]; Th.K. heading and age at death--></p>
+                <p>
+                    <!--commented out pending revision-->
+                    <!--Text is a mess; Kaibel, l.2 : Ποστούμιος; l.3: Κλ(αυδίᾳ) Σωφ[ροσύνῃ]; Th.K. heading and age at death-->
+                </p>
             </div>
             <div type="bibliography">
                 <listBibl type="edition">
@@ -219,19 +244,24 @@
                             <ref target="https://clio.columbia.edu/catalog/6873760">14.0035</ref>
                         </citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/Q2SBPG9F"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001072">https://biblio.inscriptiones.org/epig10001072</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001072">https://biblio.inscriptiones.org/epig10001072</ref>
+                    </bibl>
                     <bibl type="corpus" n="CIG">
                         <citedRange>3.5416</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/HTUDQBXS"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001252">https://biblio.inscriptiones.org/epig10001252</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001252">https://biblio.inscriptiones.org/epig10001252</ref>
+                    </bibl>
                     <bibl>
                         <author>Korhonen</author>
                         <date>2007</date>
                         <citedRange>294, nn.25-26</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/PTW9C3GD"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001485">https://biblio.inscriptiones.org/epig10001485</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001485">https://biblio.inscriptiones.org/epig10001485</ref>
+                    </bibl>
                 </listBibl>
-	   <listBibl type="discussion"><bibl/></listBibl>
+                <listBibl type="discussion">
+                    <bibl/>
+                </listBibl>
             </div>
         </body>
     </text>

--- a/inscriptions/ISic000853.xml
+++ b/inscriptions/ISic000853.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../schematron/ircyr-checking.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">
@@ -9,7 +9,9 @@
                 <editor ref="#JP">Jonathan Prag</editor>
                 <principal ref="#JP">Susan Walker</principal>
                 <funder>John Fell OUP Research Fund</funder>
-	   <funder><ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref></funder>
+                <funder>
+                    <ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref>
+                </funder>
                 <respStmt>
                     <name xml:id="JP" ref="http://orcid.org/0000-0003-3819-8537">Jonathan Prag</name>
                     <resp>original data collection and editing</resp>
@@ -38,11 +40,11 @@
                     <name xml:id="system">system</name>
                     <resp>automated or batch processes</resp>
                 </respStmt>
-	    <respStmt>
-     	       <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
-     	       <resp>standardisation of template and tidying up encoding</resp>
- 	   </respStmt>
-	</titleStmt>
+                <respStmt>
+                    <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
+                    <resp>standardisation of template and tidying up encoding</resp>
+                </respStmt>
+            </titleStmt>
             <publicationStmt>
                 <authority>I.Sicily</authority>
                 <idno type="filename">ISic000853</idno>
@@ -92,14 +94,14 @@
                                     </dimensions>
                                 </support>
                                 <condition/>
-		    </supportDesc>
+                            </supportDesc>
                             <layoutDesc>
                                 <layout>
                                     <p>Greek text over 6 lines, becoming more compressed towards the end. The letters are very deeply cut with a bull-nosed chisel, and are painted in red.</p>
                                     <rs ana="#execution.chiselled" ref="http://www.eagle-network.eu/voc/writing/lod/1">chiselled</rs>
                                     <rs ana="#execution.rubrication.red">Rubrication, red coloured</rs>
-                                	<damage/>
-			</layout>
+                                    <damage/>
+                                </layout>
                             </layoutDesc>
                         </objectDesc>
                         <handDesc>
@@ -119,15 +121,18 @@
                     <history>
                         <origin>
                             <origPlace>
-                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462503">Syracusae</placeName>		
+                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462503">Syracusae</placeName>
                                 <placeName type="modern" ref="http://sws.geonames.org/2523083">Siracusa</placeName>
-                            	<geo>37.08415, 15.27628</geo>
-		</origPlace>
+                                <geo>37.08415, 15.27628</geo>
+                            </origPlace>
                             <origDate datingMethod="#julian" notBefore-custom="0001" notAfter-custom="0200"/>
                         </origin>
-                        <provenance type="found" subtype="discovered">Salvatore Politi (ap. IG XIV.36) reports found next to the so-called 'tomb of Archimedes', a rock-cut tomb in the Grotticelli necropolis<geo>37.078359, 15.281140</geo></provenance>
+                        <provenance type="found" subtype="discovered">
+                            Salvatore Politi (ap. IG XIV.36) reports found next to the so-called 'tomb of Archimedes', a rock-cut tomb in the Grotticelli necropolis<geo>37.078359, 15.281140</geo>
+                        </provenance>
                         <provenance type="observed">According to Wilshere (letter to De Rossi), 'da un fosso sulle confine di Caradicia (? illegible) ed Epipoli'</provenance>
-                        <provenance type="observed">According to Ferrua 1941 reporting De Rossi, 'trovata in una fossa tra Agradina e Tyche'.</provenance> <!-- sort these -->
+                        <provenance type="observed">According to Ferrua 1941 reporting De Rossi, 'trovata in una fossa tra Agradina e Tyche'.</provenance>
+                        <!-- sort these -->
                         <provenance type="observed" subtype="autopsied">Walker 2015</provenance>
                         <acquisition>Transported to Siracusa museum in 1880 after discovery, but then purchased by Wilshere in May 1885; subsequently in the Wilshere collection at Pusey House; now in the Ashmolean</acquisition>
                     </history>
@@ -135,18 +140,18 @@
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
-             <p>Encoded following the latest EpiDoc guidelines</p>
-             <xi:include href="../alists/ISicily-taxonomies.xml">
-                 <xi:fallback>
-                     <p>Taxonomies for ISicily controlled values</p>
-                 </xi:fallback>
-             </xi:include>
-	  <xi:include href="../alists/charDecl.xml">
-	     <xi:fallback>
-	       <p>ISicily glyphs authority list</p>
-	     </xi:fallback>
-	   </xi:include>
-         </encodingDesc>
+            <p>Encoded following the latest EpiDoc guidelines</p>
+            <xi:include href="../alists/ISicily-taxonomies.xml">
+                <xi:fallback>
+                    <p>Taxonomies for ISicily controlled values</p>
+                </xi:fallback>
+            </xi:include>
+            <xi:include href="../alists/charDecl.xml">
+                <xi:fallback>
+                    <p>ISicily glyphs authority list</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
             <calendarDesc>
                 <calendar xml:id="julian">
@@ -177,40 +182,65 @@
                 <change when="2016-12-03" who="#JCu">James Cummings autogenerated EpiDoc output from database</change>
                 <change when="2018-02-08" who="#JP">Jonathan Prag edited the file on the basis of draft of new edition by Susan Walker</change>
                 <change when="2020-09-10" who="#system">Updated Zenodo DOI</change>
-            	   <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
-            	   <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
-            	<change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
-		<change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
-	    <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
-            	<change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
-	</listChange>
+                <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
+                <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
+                <change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
+                <change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
+                <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
+                <change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
+            </listChange>
         </revisionDesc>
     </teiHeader>
     <facsimile>
-         <surface type="front">
+        <surface type="front">
             <graphic n="screen" url="ISic000853_tiled.tif" height="768px" width="1000px">
                 <desc>Photo Gower, courtesy Ashmolean museum</desc>
             </graphic>
             <graphic n="print" url="ISic000853.jpg" height="768px" width="1000px">
-                <desc>Photo Gower, courtesy Ashmolean museum</desc>    </graphic>
-      </surface>
-   </facsimile>
+                <desc>Photo Gower, courtesy Ashmolean museum</desc>
+            </graphic>
+        </surface>
+    </facsimile>
     <text>
         <body>
             <div type="edition" xml:space="preserve" xml:lang="grc" resp="#SW">
                 <ab>
-                    <lb n="1"/><supplied reason="lost"><expan><abbr>Θ</abbr><ex>εοῖς</ex></expan></supplied> · <expan><abbr>Κ</abbr><ex>αταχθονίοις</ex></expan>
-                    <lb n="2"/><expan><abbr>Κ</abbr><ex>λαυδία</ex></expan> · Σωτή<supplied reason="lost">ρ</supplied>ις
-                    <lb n="3"/>χρηστὰ <unclear>κ</unclear><unclear>α</unclear>ὶ
-                    <lb n="4"/>ἄ<hi rend="ligature">με</hi><hi rend="ligature">μπ</hi>τ<hi rend="ligature">ος</hi> <expan><abbr>ἔζ</abbr><ex>ησεν</ex></expan>
-                    <lb n="5"/>ἔ<hi rend="ligature">τη</hi> · ξγ’ · <expan><abbr><hi rend="ligature">μῆ</hi></abbr><ex>νας</ex></expan> · γ’ · <expan><abbr><hi rend="ligature">ἡμέ</hi></abbr><ex>ρας</ex></expan> θ’ 
+                    <lb n="1"/><w n="5"><supplied reason="lost"><expan><abbr>Θ</abbr><ex>εοῖς</ex></expan></supplied></w> <g ref="#interpunct">·</g> <w n="10"><expan><abbr>Κ</abbr><ex>αταχθονίοις</ex></expan></w>
+                    <lb n="2"/><w n="15"><expan><abbr>Κ</abbr><ex>λαυδία</ex></expan></w> <g ref="#interpunct">·</g> <w n="20">Σωτή<supplied reason="lost">ρ</supplied>ις</w>
+                    <lb n="3"/><w n="25">χρηστὰ</w> <w n="30"><unclear>κ</unclear><unclear>α</unclear>ὶ</w>
+                    <lb n="4"/><w n="35">ἄ<hi rend="ligature">με</hi><hi rend="ligature">μπ</hi>τ<hi rend="ligature">ος</hi></w> <w n="40"><expan><abbr>ἔζ</abbr><ex>ησεν</ex></expan></w>
+                    <lb n="5"/><w n="45">ἔ<hi rend="ligature">τη</hi></w> <g ref="#interpunct">·</g> <w n="50">ξγ’</w> <g ref="#interpunct">·</g> <w n="55"><expan><abbr><hi rend="ligature">μῆ</hi></abbr><ex>νας</ex></expan></w> <g ref="#interpunct">·</g> <w n="60">γ’</w> <g ref="#interpunct">·</g> <w n="65"><expan><abbr><hi rend="ligature">ἡμέ</hi></abbr><ex>ρας</ex></expan></w> <w n="70">θ’</w>
+                </ab>
+            </div>
+            <div type="edition" subtype="simple-lemmatized">
+                <ab>
+                    <w n="5" lemma="θεός">Θεοῖς</w>
+                    <w n="10" lemma="καταχθόνιος">Καταχθονίοις</w>
+                    <w n="15" lemma="Κλαυδία">Κλαυδία</w>
+                    <w n="20" lemma="Σωτήρις">Σωτήρις</w>
+                    <w n="25" lemma="χρηστός">χρηστὰ</w>
+                    <w n="30" lemma="καί">καὶ</w>
+                    <w n="35" lemma="ἄμεμπτος">ἄμεμπτος</w>
+                    <w n="40" lemma="ζάω">ἔζησεν</w>
+                    <w n="45" lemma="ἔτος">ἔτη</w>
+                    <w n="50" lemma="ξγ᾽">ξγ’</w>
+                    <w n="55" lemma="μείς">μῆνας</w>
+                    <w n="60" lemma="γ᾽">γ’</w>
+                    <w n="65" lemma="ἡμέρα">ἡμέρας</w>
+                    <w n="70" lemma="θ᾽">θ’</w>
                 </ab>
             </div>
             <div type="apparatus">
                 <listApp>
-                    <app loc="line 2"><note>Σωτήρ[ις], Kaibel</note></app>
-                    <app loc="line 3"><note>κ[αὶ], Kaibel</note></app>
-                    <app loc="line 5"><note>ἔτη · ζγ’ · μῆνας · ε’, Webster</note></app>
+                    <app loc="line 2">
+                        <note>Σωτήρ[ις], Kaibel</note>
+                    </app>
+                    <app loc="line 3">
+                        <note>κ[αὶ], Kaibel</note>
+                    </app>
+                    <app loc="line 5">
+                        <note>ἔτη · ζγ’ · μῆνας · ε’, Webster</note>
+                    </app>
                 </listApp>
             </div>
             <div type="translation" xml:lang="en" resp="#SW">
@@ -228,25 +258,31 @@
                             <ref target="https://clio.columbia.edu/catalog/6873760">14.0036</ref>
                         </citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/Q2SBPG9F"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001072">https://biblio.inscriptiones.org/epig10001072</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001072">https://biblio.inscriptiones.org/epig10001072</ref>
+                    </bibl>
                     <bibl>
                         <author>Webster</author>
                         <date>1929</date>
                         <citedRange>152 no.21</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/SS75U98Q"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001516">https://biblio.inscriptiones.org/epig10001516</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001516">https://biblio.inscriptiones.org/epig10001516</ref>
+                    </bibl>
                     <bibl>
                         <author>Ferrua</author>
                         <date>1941</date>
                         <citedRange>197-198 no.68 fig.34</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/4HR4GXBX"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001456">https://biblio.inscriptiones.org/epig10001456</ref></bibl>
-                    <bibl><!-- needs updating -->
+                        <ref target="https://biblio.inscriptiones.org/epig10001456">https://biblio.inscriptiones.org/epig10001456</ref>
+                    </bibl>
+                    <bibl>
+                        <!-- needs updating -->
                         <author>Walker</author>
                         <date>forthcoming</date>
                     </bibl>
                 </listBibl>
-	   <listBibl type="discussion"><bibl/></listBibl>
+                <listBibl type="discussion">
+                    <bibl/>
+                </listBibl>
             </div>
         </body>
     </text>

--- a/inscriptions/ISic000855.xml
+++ b/inscriptions/ISic000855.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../schematron/ircyr-checking.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">
@@ -9,7 +9,9 @@
                 <editor ref="#JP">Jonathan Prag</editor>
                 <principal ref="#JP">Jonathan Prag</principal>
                 <funder>John Fell OUP Research Fund</funder>
-	   <funder><ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref></funder>
+                <funder>
+                    <ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref>
+                </funder>
                 <respStmt>
                     <name xml:id="JP" ref="http://orcid.org/0000-0003-3819-8537">Jonathan Prag</name>
                     <resp>original data collection and editing</resp>
@@ -30,15 +32,15 @@
                     <name xml:id="MM">Michael Metcalfe</name>
                     <resp>museum data collection</resp>
                 </respStmt>
-	    <respStmt>
-     	       <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
-     	       <resp>standardisation of template and tidying up encoding</resp>
- 	   </respStmt>
+                <respStmt>
+                    <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
+                    <resp>standardisation of template and tidying up encoding</resp>
+                </respStmt>
                 <respStmt>
                     <name xml:id="VM" ref="https://orcid.org/0000-0002-7122-2511">Valentina Mignosa</name>
                     <resp>encoding text division and checking the edition</resp>
                 </respStmt>
-	    <respStmt>
+                <respStmt>
                     <name xml:id="system">system</name>
                     <resp>automated or batch processes</resp>
                 </respStmt>
@@ -81,23 +83,26 @@
                                 <support>
                                     <material ana="#material.stone" ref="http://www.eagle-network.eu/voc/material/lod/2.html">stone</material>
                                     <objectType ana="#object.stele" ref="http://www.eagle-network.eu/voc/objtyp/lod/250.html">stele</objectType>
-                                    <dimensions><!--inv-->
+                                    <dimensions>
+                                        <!--inv-->
                                         <height unit="cm">60</height>
                                         <width unit="cm">41</width>
                                         <depth unit="cm"/>
                                     </dimensions>
                                 </support>
                                 <condition/>
-		    </supportDesc>
+                            </supportDesc>
                             <layoutDesc>
-                                <layout><!--Default value and requires checking-->
+                                <layout>
+                                    <!--Default value and requires checking-->
                                     <rs ana="#execution.chiselled" ref="http://www.eagle-network.eu/voc/writing/lod/1">chiselled</rs>
-                                	<damage/>
-			</layout>
+                                    <damage/>
+                                </layout>
                             </layoutDesc>
                         </objectDesc>
                         <handDesc>
-                            <handNote><!--Default value and requires editing-->
+                            <handNote>
+                                <!--Default value and requires editing-->
                                 <locus from="line1" to="line1">Line 1</locus>
                                 <dimensions type="letterHeight">
                                     <height unit="mm"/>
@@ -112,10 +117,10 @@
                     <history>
                         <origin>
                             <origPlace>
-                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462503">Syracusae</placeName>		
+                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462503">Syracusae</placeName>
                                 <placeName type="modern" ref="http://sws.geonames.org/2523083">Siracusa</placeName>
-                            	<geo>37.08415, 15.27628</geo>
-		</origPlace>
+                                <geo>37.08415, 15.27628</geo>
+                            </origPlace>
                             <origDate datingMethod="#julian" notBefore-custom="0101" notAfter-custom="0400" precision="low">Full tria nomina; woman's age in yrs and months (?)</origDate>
                         </origin>
                         <provenance type="found">Original discovery not recorded.</provenance>
@@ -126,18 +131,18 @@
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
-             <p>Encoded following the latest EpiDoc guidelines</p>
-             <xi:include href="../alists/ISicily-taxonomies.xml">
-                 <xi:fallback>
-                     <p>Taxonomies for ISicily controlled values</p>
-                 </xi:fallback>
-             </xi:include>
-	  <xi:include href="../alists/charDecl.xml">
-	     <xi:fallback>
-	       <p>ISicily glyphs authority list</p>
-	     </xi:fallback>
-	   </xi:include>
-         </encodingDesc>
+            <p>Encoded following the latest EpiDoc guidelines</p>
+            <xi:include href="../alists/ISicily-taxonomies.xml">
+                <xi:fallback>
+                    <p>Taxonomies for ISicily controlled values</p>
+                </xi:fallback>
+            </xi:include>
+            <xi:include href="../alists/charDecl.xml">
+                <xi:fallback>
+                    <p>ISicily glyphs authority list</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
             <calendarDesc>
                 <calendar xml:id="julian">
@@ -166,15 +171,15 @@
         <revisionDesc status="draft">
             <listChange>
                 <change when="2016-12-03" who="#JCu">James Cummings autogenerated EpiDoc output from database</change>
-            	   <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
-            	   <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
-                            <change when="2020-11-03" who="#VM">Valentina Mignosa encoded text division, cleaned up the autogenerated text and checked the edition</change>
+                <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
+                <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
+                <change when="2020-11-03" who="#VM">Valentina Mignosa encoded text division, cleaned up the autogenerated text and checked the edition</change>
                 <change when="2020-11-11" who="#JP">Jonathan Prag added inventory nr</change>
-            	<change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
-		<change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
-	    <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
-            	<change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
-	</listChange>
+                <change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
+                <change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
+                <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
+                <change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
+            </listChange>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -185,17 +190,29 @@
             <graphic n="print" url="ISic000855.jpg" height="3680px" width="5520px">
                 <desc>I.Sicily with the permission of the Assessorato Regionale dei Beni Culturali e dell’Identità Siciliana - Dipartimento dei Beni Culturali e dell’Identità Siciliana</desc>
             </graphic>
-         </surface>
+        </surface>
     </facsimile>
     <text>
         <body>
             <div type="edition" xml:space="preserve" xml:lang="grc" resp="#VM">
                 <ab>
-                    <lb n="1"/>Λοῦκις <g ref="#interpunct">·</g> Κορνῆλι<supplied reason="lost">ς</supplied>
-                    <lb n="2"/>Ὀνήσιμος
+                    <lb n="1"/><w n="5">Λοῦκις</w> <g ref="#interpunct">·</g> <w n="10">Κορνῆλι<supplied reason="lost">ς</supplied></w>
+                    <lb n="2"/><w n="15">Ὀνήσιμος</w>
                     <lb n="2a"/><space extent="1" unit="line"/>
-                    <lb n="3"/>Ὑγία <g ref="#interpunct">·</g> ἐτῶν <gap reason="lost" quantity="2" unit="character"/>
-                    <lb n="4"/>μηνῶ<supplied reason="lost">ν</supplied> <gap reason="lost" quantity="2" unit="character"/>
+                    <lb n="3"/><w n="20">Ὑγία</w> <g ref="#interpunct">·</g> <w n="25">ἐτῶν</w> <gap reason="lost" quantity="2" unit="character"/>
+                    <lb n="4"/><w n="30">μηνῶ<supplied reason="lost">ν</supplied></w> <gap reason="lost" quantity="2" unit="character"/>
+                </ab>
+            </div>
+            <div type="edition" subtype="simple-lemmatized">
+                <ab>
+                    <w n="5" lemma="Λοῦκις">Λοῦκις</w>
+                    <w n="10" lemma="Κορνῆλις">Κορνῆλις</w>
+                    <w n="15" lemma="Ὀνήσιμος">Ὀνήσιμος</w>
+                    <w n="20" lemma="Ὑγία">Ὑγία</w>
+                    <w n="25" lemma="ἔτος">ἐτῶν</w>
+                    <gap reason="lost" quantity="2" unit="character"/>
+                    <w n="30" lemma="μείς">μηνῶν</w>
+                    <gap reason="lost" quantity="2" unit="character"/>
                 </ab>
             </div>
             <div type="apparatus">
@@ -206,11 +223,15 @@
                 </listApp>
             </div>
             <div type="translation">
-                <p><!--translation(s) - add @xml:lang for 'en' or 'it' to div--></p>
+                <p>
+                    <!--translation(s) - add @xml:lang for 'en' or 'it' to div-->
+                </p>
             </div>
             <div type="commentary">
-                <p><!--commented out pending revision-->
-                    <!--Loukis Kornelis Onesimos; wife? below, Hygia, with age in years and months--></p>
+                <p>
+                    <!--commented out pending revision-->
+                    <!--Loukis Kornelis Onesimos; wife? below, Hygia, with age in years and months-->
+                </p>
             </div>
             <div type="bibliography">
                 <listBibl type="edition">
@@ -219,13 +240,17 @@
                             <ref target="https://clio.columbia.edu/catalog/6873760">14.0038</ref>
                         </citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/Q2SBPG9F"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001072">https://biblio.inscriptiones.org/epig10001072</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001072">https://biblio.inscriptiones.org/epig10001072</ref>
+                    </bibl>
                     <bibl type="corpus" n="CIG">
                         <citedRange>3.5407</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/HTUDQBXS"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001252">https://biblio.inscriptiones.org/epig10001252</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001252">https://biblio.inscriptiones.org/epig10001252</ref>
+                    </bibl>
                 </listBibl>
-	   <listBibl type="discussion"><bibl/></listBibl>
+                <listBibl type="discussion">
+                    <bibl/>
+                </listBibl>
             </div>
         </body>
     </text>

--- a/inscriptions/ISic000857.xml
+++ b/inscriptions/ISic000857.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../schematron/ircyr-checking.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">
@@ -9,7 +9,9 @@
                 <editor ref="#JP">Jonathan Prag</editor>
                 <principal ref="#JP">Jonathan Prag</principal>
                 <funder>John Fell OUP Research Fund</funder>
-	   <funder><ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref></funder>
+                <funder>
+                    <ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref>
+                </funder>
                 <respStmt>
                     <name xml:id="JP" ref="http://orcid.org/0000-0003-3819-8537">Jonathan Prag</name>
                     <resp>original data collection and editing</resp>
@@ -30,11 +32,11 @@
                     <name xml:id="MM">Michael Metcalfe</name>
                     <resp>museum data collection</resp>
                 </respStmt>
-	    <respStmt>
-     	       <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
-     	       <resp>standardisation of template and tidying up encoding</resp>
- 	   </respStmt>
-	    <respStmt>
+                <respStmt>
+                    <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
+                    <resp>standardisation of template and tidying up encoding</resp>
+                </respStmt>
+                <respStmt>
                     <name xml:id="system">system</name>
                     <resp>automated or batch processes</resp>
                 </respStmt>
@@ -79,23 +81,25 @@
                                 <support>
                                     <material ana="#material.stone" ref="http://www.eagle-network.eu/voc/material/lod/2.html">stone</material>
                                     <objectType ana="#object.unknown" ref="http://www.eagle-network.eu/voc/objtyp/lod/2.html">unknown</objectType>
-                                    <dimensions><!--Default values and requires editing-->
+                                    <dimensions>
+                                        <!--Default values and requires editing-->
                                         <height unit="cm"/>
                                         <width unit="cm"/>
                                         <depth unit="cm"/>
                                     </dimensions>
                                 </support>
                                 <condition/>
-		    </supportDesc>
+                            </supportDesc>
                             <layoutDesc>
                                 <layout>
                                     <rs ana="#execution.chiselled" ref="http://www.eagle-network.eu/voc/writing/lod/1">chiselled</rs>
-                                	<damage/>
-			</layout>
+                                    <damage/>
+                                </layout>
                             </layoutDesc>
                         </objectDesc>
                         <handDesc>
-                            <handNote><!--Default value and requires editing-->
+                            <handNote>
+                                <!--Default value and requires editing-->
                                 <locus from="line1" to="line1">Line 1</locus>
                                 <dimensions type="letterHeight">
                                     <height unit="mm"/>
@@ -110,13 +114,15 @@
                     <history>
                         <origin>
                             <origPlace>
-                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462503">Syracusae</placeName>		
+                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462503">Syracusae</placeName>
                                 <placeName type="modern" ref="http://sws.geonames.org/2523083">Siracusa</placeName>
-                            	<geo>37.08415, 15.27628</geo>
-		</origPlace>
+                                <geo>37.08415, 15.27628</geo>
+                            </origPlace>
                             <origDate datingMethod="#julian" notBefore-custom="0100" notAfter-custom="0400">Imperial</origDate>
                         </origin>
-                        <provenance type="found" subtype="discovered">"nel cimitero de' Cappucini"<geo>37.078240, 15.295153</geo></provenance>
+                        <provenance type="found" subtype="discovered">
+                            "nel cimitero de' Cappucini"<geo>37.078240, 15.295153</geo>
+                        </provenance>
                         <provenance type="observed" subtype="autopsied">None</provenance>
                         <acquisition/>
                     </history>
@@ -124,18 +130,18 @@
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
-             <p>Encoded following the latest EpiDoc guidelines</p>
-             <xi:include href="../alists/ISicily-taxonomies.xml">
-                 <xi:fallback>
-                     <p>Taxonomies for ISicily controlled values</p>
-                 </xi:fallback>
-             </xi:include>
-	  <xi:include href="../alists/charDecl.xml">
-	     <xi:fallback>
-	       <p>ISicily glyphs authority list</p>
-	     </xi:fallback>
-	   </xi:include>
-         </encodingDesc>
+            <p>Encoded following the latest EpiDoc guidelines</p>
+            <xi:include href="../alists/ISicily-taxonomies.xml">
+                <xi:fallback>
+                    <p>Taxonomies for ISicily controlled values</p>
+                </xi:fallback>
+            </xi:include>
+            <xi:include href="../alists/charDecl.xml">
+                <xi:fallback>
+                    <p>ISicily glyphs authority list</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
             <calendarDesc>
                 <calendar xml:id="julian">
@@ -165,13 +171,13 @@
             <listChange>
                 <change when="2016-12-03" who="#JCu">James Cummings autogenerated EpiDoc output from database</change>
                 <change when="2020-09-10" who="#JP">Jonathan Prag made preliminary revision of epidoc from IG</change>
-            	   <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
-            	   <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
-            	<change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
-		<change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
-	    <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
-            	<change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
-	</listChange>
+                <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
+                <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
+                <change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
+                <change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
+                <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
+                <change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
+            </listChange>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -182,27 +188,51 @@
             <graphic n="print" url="ISic000857.jpg" height="3680px" width="5520px">
                 <desc>I.Sicily with the permission of the Assessorato Regionale dei Beni Culturali e dell’Identità Siciliana - Dipartimento dei Beni Culturali e dell’Identità Siciliana</desc>
             </graphic>
-         </surface></facsimile>
+        </surface>
+    </facsimile>
     <text>
         <body>
             <div type="edition" xml:space="preserve" xml:lang="grc" resp="#JP">
                 <ab>
-                    <lb n="1"/>Λεο<supplied reason="omitted">σ</supplied>θένης
-                    <lb n="2"/>Λέπιδος
-                    <lb n="3"/>καὶ Ἐράσμιος
-                    <lb n="4"/>ἔζησες ἔτ<supplied reason="omitted">η</supplied> <num value="20"><hi rend="supraline">κ</hi></num>
-                    <lb n="5"/><expan><abbr>μῆν</abbr><ex>ας</ex></expan> · <num value="4">δ</num> · <expan><abbr>ἡμέρ</abbr><ex>ας</ex></expan> <num value="8">η</num>
-              </ab>
+                    <lb n="1"/><w n="5">Λεο<supplied reason="omitted">σ</supplied>θένης</w>
+                    <lb n="2"/><w n="10">Λέπιδος</w>
+                    <lb n="3"/><w n="15">καὶ</w> <w n="20">Ἐράσμιος</w>
+                    <lb n="4"/><w n="25">ἔζησες</w> <w n="30">ἔτ<supplied reason="omitted">η</supplied></w> <num value="20"><w n="35"><hi rend="supraline">κ</hi></w></num>
+                    <lb n="5"/><w n="40"><expan><abbr>μῆν</abbr><ex>ας</ex></expan></w> <g ref="#interpunct">·</g> <num value="4"><w n="45">δ</w></num> <g ref="#interpunct">·</g> <w n="50"><expan><abbr>ἡμέρ</abbr><ex>ας</ex></expan></w> <num value="8"><w n="55">η</w></num>
+                </ab>
+            </div>
+            <div type="edition" subtype="simple-lemmatized">
+                <ab>
+                    <w n="5" lemma="Λεοσθένης">Λεοσθένης</w>
+                    <w n="10" lemma="Λέπις">Λέπιδος</w>
+                    <w n="15" lemma="καί">καὶ</w>
+                    <w n="20" lemma="Ἐράσμιος">Ἐράσμιος</w>
+                    <w n="25" lemma="ζάω">ἔζησες</w>
+                    <w n="30" lemma="ἔτος">ἔτη</w>
+                    <w n="35" lemma="κ">κ</w>
+                    <w n="40" lemma="μείς">μῆνας</w>
+                    <w n="45" lemma="δ">δ</w>
+                    <w n="50" lemma="ἡμέρα">ἡμέρας</w>
+                    <w n="55" lemma="η">η</w>
+                </ab>
             </div>
             <div type="apparatus">
-                <listApp><app><note>Text of IG</note></app></listApp>
+                <listApp>
+                    <app>
+                        <note>Text of IG</note>
+                    </app>
+                </listApp>
             </div>
             <div type="translation">
-                <p><!--translation(s) - add @xml:lang for 'en' or 'it' to div--></p>
+                <p>
+                    <!--translation(s) - add @xml:lang for 'en' or 'it' to div-->
+                </p>
             </div>
             <div type="commentary">
-                <p><!--commented out pending revision-->
-                    <!--Leothenes, commemorated by Lepidos (latin name) and Erasmius (gr. name); age in yrs, months, days.--></p>
+                <p>
+                    <!--commented out pending revision-->
+                    <!--Leothenes, commemorated by Lepidos (latin name) and Erasmius (gr. name); age in yrs, months, days.-->
+                </p>
             </div>
             <div type="bibliography">
                 <listBibl type="edition">
@@ -211,24 +241,30 @@
                             <ref target="https://clio.columbia.edu/catalog/6873760">14.0040</ref>
                         </citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/Q2SBPG9F"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001072">https://biblio.inscriptiones.org/epig10001072</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001072">https://biblio.inscriptiones.org/epig10001072</ref>
+                    </bibl>
                     <bibl type="corpus" n="CIG">
                         <citedRange>3.5403</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/HTUDQBXS"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001252">https://biblio.inscriptiones.org/epig10001252</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001252">https://biblio.inscriptiones.org/epig10001252</ref>
+                    </bibl>
                     <bibl>
                         <author>Manganaro</author>
                         <date>1988</date>
                         <citedRange>49 n.244</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/RZSFKACR"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001427">https://biblio.inscriptiones.org/epig10001427</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001427">https://biblio.inscriptiones.org/epig10001427</ref>
+                    </bibl>
                     <bibl>
                         <author>Korhonen</author>
                         <date>2007</date>
                         <ptr target="https://www.zotero.org/groups/382445/items/PTW9C3GD"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001485">https://biblio.inscriptiones.org/epig10001485</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001485">https://biblio.inscriptiones.org/epig10001485</ref>
+                    </bibl>
                 </listBibl>
-	   <listBibl type="discussion"><bibl/></listBibl>
+                <listBibl type="discussion">
+                    <bibl/>
+                </listBibl>
             </div>
         </body>
     </text>

--- a/inscriptions/ISic000858.xml
+++ b/inscriptions/ISic000858.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../schematron/ircyr-checking.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">
@@ -9,7 +9,9 @@
                 <editor ref="#JP">Jonathan Prag</editor>
                 <principal ref="#JP">Jonathan Prag</principal>
                 <funder>John Fell OUP Research Fund</funder>
-	   <funder><ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref></funder>
+                <funder>
+                    <ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref>
+                </funder>
                 <respStmt>
                     <name xml:id="JP" ref="http://orcid.org/0000-0003-3819-8537">Jonathan Prag</name>
                     <resp>original data collection and editing</resp>
@@ -30,15 +32,15 @@
                     <name xml:id="MM">Michael Metcalfe</name>
                     <resp>museum data collection</resp>
                 </respStmt>
-	    <respStmt>
-     	       <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
-     	       <resp>standardisation of template and tidying up encoding</resp>
- 	   </respStmt>
+                <respStmt>
+                    <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
+                    <resp>standardisation of template and tidying up encoding</resp>
+                </respStmt>
                 <respStmt>
                     <name xml:id="VM" ref="https://orcid.org/0000-0002-7122-2511">Valentina Mignosa</name>
                     <resp>encoding text division and checking the edition</resp>
                 </respStmt>
-	    <respStmt>
+                <respStmt>
                     <name xml:id="system">system</name>
                     <resp>automated or batch processes</resp>
                 </respStmt>
@@ -61,11 +63,14 @@
             </publicationStmt>
             <sourceDesc>
                 <msDesc>
-                    <msIdentifier><!--Default country and region-->
+                    <msIdentifier>
+                        <!--Default country and region-->
                         <country>Italy</country>
                         <region>Sicily</region>
                         <settlement>Siracusa</settlement>
-                        <repository><!--Add Repository Here--></repository>
+                        <repository>
+                            <!--Add Repository Here-->
+                        </repository>
                         <!--No inventory number found-->
                         <!--Adding location for old id numbers if available-->
                         <altIdentifier>
@@ -82,23 +87,26 @@
                             <supportDesc>
                                 <support>
                                     <material ana="#material.stone.marble" ref="http://www.eagle-network.eu/voc/material/lod/48.html">marble</material>
-                                    <dimensions><!--Default values and requires editing-->
+                                    <dimensions>
+                                        <!--Default values and requires editing-->
                                         <height unit="cm"/>
                                         <width unit="cm"/>
                                         <depth unit="cm"/>
                                     </dimensions>
                                 </support>
                                 <condition/>
-		    </supportDesc>
+                            </supportDesc>
                             <layoutDesc>
-                                <layout><!--Default value and requires checking-->
+                                <layout>
+                                    <!--Default value and requires checking-->
                                     <rs ana="#execution.chiselled" ref="http://www.eagle-network.eu/voc/writing/lod/1">chiselled</rs>
-                                	<damage/>
-			</layout>
+                                    <damage/>
+                                </layout>
                             </layoutDesc>
                         </objectDesc>
                         <handDesc>
-                            <handNote><!--Default value and requires editing-->
+                            <handNote>
+                                <!--Default value and requires editing-->
                                 <locus from="line1" to="line1">Line 1</locus>
                                 <dimensions type="letterHeight">
                                     <height unit="mm"/>
@@ -113,10 +121,10 @@
                     <history>
                         <origin>
                             <origPlace>
-                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462503">Syracusae</placeName>		
+                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462503">Syracusae</placeName>
                                 <placeName type="modern" ref="http://sws.geonames.org/2523083">Siracusa</placeName>
-                            	<geo>37.08415, 15.27628</geo>
-		</origPlace>
+                                <geo>37.08415, 15.27628</geo>
+                            </origPlace>
                             <origDate datingMethod="#julian" cert="low">(?)</origDate>
                         </origin>
                         <provenance type="found">Original discovery not recorded.</provenance>
@@ -127,18 +135,18 @@
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
-             <p>Encoded following the latest EpiDoc guidelines</p>
-             <xi:include href="../alists/ISicily-taxonomies.xml">
-                 <xi:fallback>
-                     <p>Taxonomies for ISicily controlled values</p>
-                 </xi:fallback>
-             </xi:include>
-	  <xi:include href="../alists/charDecl.xml">
-	     <xi:fallback>
-	       <p>ISicily glyphs authority list</p>
-	     </xi:fallback>
-	   </xi:include>
-         </encodingDesc>
+            <p>Encoded following the latest EpiDoc guidelines</p>
+            <xi:include href="../alists/ISicily-taxonomies.xml">
+                <xi:fallback>
+                    <p>Taxonomies for ISicily controlled values</p>
+                </xi:fallback>
+            </xi:include>
+            <xi:include href="../alists/charDecl.xml">
+                <xi:fallback>
+                    <p>ISicily glyphs authority list</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
             <calendarDesc>
                 <calendar xml:id="julian">
@@ -167,14 +175,14 @@
         <revisionDesc status="draft">
             <listChange>
                 <change when="2016-12-03" who="#JCu">James Cummings autogenerated EpiDoc output from database</change>
-            	   <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
-            	   <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
-                            <change when="2020-11-03" who="#VM">Valentina Mignosa encoded text division, cleaned up the autogenerated text and checked the edition</change>
-            	<change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
-		<change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
-	    <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
-            	<change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
-	</listChange>
+                <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
+                <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
+                <change when="2020-11-03" who="#VM">Valentina Mignosa encoded text division, cleaned up the autogenerated text and checked the edition</change>
+                <change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
+                <change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
+                <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
+                <change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
+            </listChange>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -185,16 +193,29 @@
             <graphic n="print" url="ISic000858.jpg" height="3680px" width="5520px">
                 <desc>I.Sicily with the permission of the Assessorato Regionale dei Beni Culturali e dell’Identità Siciliana - Dipartimento dei Beni Culturali e dell’Identità Siciliana</desc>
             </graphic>
-         </surface>
+        </surface>
     </facsimile>
     <text>
         <body>
             <div type="edition" xml:space="preserve" xml:lang="grc" resp="#VM">
                 <ab>
-                    <lb n="1"/><orig>ΞΑΡΧ</orig><gap reason="lost" extent="unknown" unit="character"/>
-                    <lb n="2"/><expan><abbr>Κ</abbr><ex cert="low">υίντος</ex></expan> <g ref="#interpunct">·</g> Λόλλι<supplied reason="lost" cert="low">ος</supplied>
-                    <lb n="3"/><orig>Δ</orig> <g ref="#interpunct">·</g> <orig>ΠΟ</orig><gap reason="lost" extent="unknown" unit="character"/>
-                    <lb n="4"/><orig>ΧΜΑΡ</orig><gap reason="lost" extent="unknown" unit="character"/>
+                    <lb n="1"/><orig n="5">ΞΑΡΧ</orig><gap reason="lost" extent="unknown" unit="character"/>
+                    <lb n="2"/><w n="10"><expan><abbr>Κ</abbr><ex cert="low">υίντος</ex></expan></w> <g ref="#interpunct">·</g> <w n="15">Λόλλι<supplied reason="lost" cert="low">ος</supplied></w>
+                    <lb n="3"/><orig n="20">Δ</orig><g ref="#interpunct">·</g> <orig n="25">ΠΟ</orig><gap reason="lost" extent="unknown" unit="character"/>
+                    <lb n="4"/><orig n="30">ΧΜΑΡ</orig><gap reason="lost" extent="unknown" unit="character"/>
+                </ab>
+            </div>
+            <div type="edition" subtype="simple-lemmatized">
+                <ab>
+                    <orig n="5">ΞΑΡΧ</orig>
+                    <gap reason="lost" extent="unknown" unit="character"/>
+                    <w n="10" lemma="Κυίντος">Κυίντος</w>
+                    <w n="15" lemma="Λόλλιος">Λόλλιος</w>
+                    <orig n="20">Δ</orig>
+                    <orig n="25">ΠΟ</orig>
+                    <gap reason="lost" extent="unknown" unit="character"/>
+                    <orig n="30">ΧΜΑΡ</orig>
+                    <gap reason="lost" extent="unknown" unit="character"/>
                 </ab>
             </div>
             <div type="apparatus">
@@ -205,11 +226,15 @@
                 </listApp>
             </div>
             <div type="translation">
-                <p><!--translation(s) - add @xml:lang for 'en' or 'it' to div--></p>
+                <p>
+                    <!--translation(s) - add @xml:lang for 'en' or 'it' to div-->
+                </p>
             </div>
             <div type="commentary">
-                <p><!--commented out pending revision-->
-                    <!--v. frag; l.2: Kaibel suggests Κυίντος or Κ(λαύδιος); Λόλλιος or Λολλι[ανὸς]; p'haps includes a Kuintos or Klaudios Lollios--></p>
+                <p>
+                    <!--commented out pending revision-->
+                    <!--v. frag; l.2: Kaibel suggests Κυίντος or Κ(λαύδιος); Λόλλιος or Λολλι[ανὸς]; p'haps includes a Kuintos or Klaudios Lollios-->
+                </p>
             </div>
             <div type="bibliography">
                 <listBibl type="edition">
@@ -218,10 +243,13 @@
                             <ref target="https://clio.columbia.edu/catalog/6873760">14.0041</ref>
                         </citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/Q2SBPG9F"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001072">https://biblio.inscriptiones.org/epig10001072</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001072">https://biblio.inscriptiones.org/epig10001072</ref>
+                    </bibl>
                     <bibl/>
                 </listBibl>
-	   <listBibl type="discussion"><bibl/></listBibl>
+                <listBibl type="discussion">
+                    <bibl/>
+                </listBibl>
             </div>
         </body>
     </text>

--- a/inscriptions/ISic000861.xml
+++ b/inscriptions/ISic000861.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../schematron/ircyr-checking.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">
@@ -9,7 +9,9 @@
                 <editor ref="#JP">Jonathan Prag</editor>
                 <principal ref="#JP">Jonathan Prag</principal>
                 <funder>John Fell OUP Research Fund</funder>
-	   <funder><ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref></funder>
+                <funder>
+                    <ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref>
+                </funder>
                 <respStmt>
                     <name xml:id="JP" ref="http://orcid.org/0000-0003-3819-8537">Jonathan Prag</name>
                     <resp>original data collection and editing</resp>
@@ -30,15 +32,15 @@
                     <name xml:id="MM">Michael Metcalfe</name>
                     <resp>museum data collection</resp>
                 </respStmt>
-	    <respStmt>
-     	       <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
-     	       <resp>standardisation of template and tidying up encoding</resp>
- 	   </respStmt>
+                <respStmt>
+                    <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
+                    <resp>standardisation of template and tidying up encoding</resp>
+                </respStmt>
                 <respStmt>
                     <name xml:id="VM" ref="https://orcid.org/0000-0002-7122-2511">Valentina Mignosa</name>
                     <resp>encoding text division and checking the edition</resp>
                 </respStmt>
-	    <respStmt>
+                <respStmt>
                     <name xml:id="system">system</name>
                     <resp>automated or batch processes</resp>
                 </respStmt>
@@ -81,23 +83,25 @@
                                 <support>
                                     <material ana="#material.stone.marble" ref="http://www.eagle-network.eu/voc/material/lod/48.html">marble</material>
                                     <objectType ana="#object.plaque" ref="https://www.eagle-network.eu/voc/objtyp/lod/259.html">plaque</objectType>
-                                    <dimensions><!--inv-->
+                                    <dimensions>
+                                        <!--inv-->
                                         <height unit="cm">16</height>
                                         <width unit="cm">30</width>
                                         <depth unit="cm"/>
                                     </dimensions>
                                 </support>
                                 <condition/>
-		    </supportDesc>
+                            </supportDesc>
                             <layoutDesc>
                                 <layout>
                                     <rs ana="#execution.chiselled" ref="http://www.eagle-network.eu/voc/writing/lod/1">chiselled</rs>
-                                	<damage/>
-			</layout>
+                                    <damage/>
+                                </layout>
                             </layoutDesc>
                         </objectDesc>
                         <handDesc>
-                            <handNote><!--Default value and requires editing-->
+                            <handNote>
+                                <!--Default value and requires editing-->
                                 <locus from="line1" to="line1">Line 1</locus>
                                 <dimensions type="letterHeight">
                                     <height unit="mm"/>
@@ -112,10 +116,10 @@
                     <history>
                         <origin>
                             <origPlace>
-                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462503">Syracusae</placeName>		
+                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462503">Syracusae</placeName>
                                 <placeName type="modern" ref="http://sws.geonames.org/2523083">Siracusa</placeName>
-                            	<geo>37.08415, 15.27628</geo>
-		</origPlace>
+                                <geo>37.08415, 15.27628</geo>
+                            </origPlace>
                             <origDate datingMethod="#julian" notBefore-custom="0100" notAfter-custom="0400">Roman</origDate>
                         </origin>
                         <provenance type="found">Found in the 'cimitero de Cappucini'</provenance>
@@ -127,18 +131,18 @@
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
-             <p>Encoded following the latest EpiDoc guidelines</p>
-             <xi:include href="../alists/ISicily-taxonomies.xml">
-                 <xi:fallback>
-                     <p>Taxonomies for ISicily controlled values</p>
-                 </xi:fallback>
-             </xi:include>
-	  <xi:include href="../alists/charDecl.xml">
-	     <xi:fallback>
-	       <p>ISicily glyphs authority list</p>
-	     </xi:fallback>
-	   </xi:include>
-         </encodingDesc>
+            <p>Encoded following the latest EpiDoc guidelines</p>
+            <xi:include href="../alists/ISicily-taxonomies.xml">
+                <xi:fallback>
+                    <p>Taxonomies for ISicily controlled values</p>
+                </xi:fallback>
+            </xi:include>
+            <xi:include href="../alists/charDecl.xml">
+                <xi:fallback>
+                    <p>ISicily glyphs authority list</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
             <calendarDesc>
                 <calendar xml:id="julian">
@@ -167,15 +171,15 @@
         <revisionDesc status="draft">
             <listChange>
                 <change when="2016-12-03" who="#JCu">James Cummings autogenerated EpiDoc output from database</change>
-            	   <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
-            	   <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
-                            <change when="2020-11-03" who="#VM">Valentina Mignosa encoded text division, cleaned up the autogenerated text and checked the edition</change>
-            	<change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
-		<change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
-	    <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
-            	<change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
+                <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
+                <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
+                <change when="2020-11-03" who="#VM">Valentina Mignosa encoded text division, cleaned up the autogenerated text and checked the edition</change>
+                <change when="2020-11-20" who="#SS">Simona Stoyanova added EDCS numbers</change>
+                <change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
+                <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
+                <change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
                 <change when="2021-08-04" who="#JP">Jonathan Prag amended repository and provenance data</change>
-	</listChange>
+            </listChange>
         </revisionDesc>
     </teiHeader>
     <facsimile>
@@ -186,16 +190,27 @@
             <graphic n="print" url="ISic000861.jpg" height="3680px" width="5520px">
                 <desc>I.Sicily with the permission of the Assessorato Regionale dei Beni Culturali e dell’Identità Siciliana - Dipartimento dei Beni Culturali e dell’Identità Siciliana</desc>
             </graphic>
-         </surface>
+        </surface>
     </facsimile>
     <text>
         <body>
             <div type="edition" xml:space="preserve" xml:lang="grc" resp="#VM">
                 <ab>
-                    <lb n="1"/><expan><abbr>Θ</abbr><ex>εοῖς</ex></expan> <expan><abbr>Κ</abbr><ex>αταχθονίοις</ex></expan>
-                    <lb n="2"/>Νεθάρι τεκνίον
-                    <lb n="3"/>χαῖρε
-                    <lb n="4"/>θανεῖν πέπρωται
+                    <lb n="1"/><w n="5"><expan><abbr>Θ</abbr><ex>εοῖς</ex></expan></w> <w n="10"><expan><abbr>Κ</abbr><ex>αταχθονίοις</ex></expan></w>
+                    <lb n="2"/><w n="15">Νεθάρι</w> <w n="20">τεκνίον</w>
+                    <lb n="3"/><w n="25">χαῖρε</w>
+                    <lb n="4"/><w n="30">θανεῖν</w> <w n="35">πέπρωται</w>
+                </ab>
+            </div>
+            <div type="edition" subtype="simple-lemmatized">
+                <ab>
+                    <w n="5" lemma="θεός">Θεοῖς</w>
+                    <w n="10" lemma="καταχθόνιος">Καταχθονίοις</w>
+                    <w n="15" lemma="Νεθάρι">Νεθάρι</w>
+                    <w n="20" lemma="τεκνίον">τεκνίον</w>
+                    <w n="25" lemma="χαίρω">χαῖρε</w>
+                    <w n="30" lemma="θνῄσκω">θανεῖν</w>
+                    <w n="35" lemma="πόρω">πέπρωται</w>
                 </ab>
             </div>
             <div type="apparatus">
@@ -206,11 +221,15 @@
                 </listApp>
             </div>
             <div type="translation">
-                <p><!--translation(s) - add @xml:lang for 'en' or 'it' to div--></p>
+                <p>
+                    <!--translation(s) - add @xml:lang for 'en' or 'it' to div-->
+                </p>
             </div>
             <div type="commentary">
-                <p><!--commented out pending revision-->
-                    <!--Nethari; Th.K. heading; chaire; last line is 'thanein peprotai'--></p>
+                <p>
+                    <!--commented out pending revision-->
+                    <!--Nethari; Th.K. heading; chaire; last line is 'thanein peprotai'-->
+                </p>
             </div>
             <div type="bibliography">
                 <listBibl type="edition">
@@ -219,18 +238,23 @@
                             <ref target="https://clio.columbia.edu/catalog/6873760">14.0044</ref>
                         </citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/Q2SBPG9F"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001072">https://biblio.inscriptiones.org/epig10001072</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001072">https://biblio.inscriptiones.org/epig10001072</ref>
+                    </bibl>
                     <bibl type="corpus" n="CIG">
                         <citedRange>3.5406</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/HTUDQBXS"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001252">https://biblio.inscriptiones.org/epig10001252</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001252">https://biblio.inscriptiones.org/epig10001252</ref>
+                    </bibl>
                     <bibl>
                         <author>Korhonen</author>
                         <date>2007</date>
                         <ptr target="https://www.zotero.org/groups/382445/items/PTW9C3GD"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001485">https://biblio.inscriptiones.org/epig10001485</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001485">https://biblio.inscriptiones.org/epig10001485</ref>
+                    </bibl>
                 </listBibl>
-	   <listBibl type="discussion"><bibl/></listBibl>
+                <listBibl type="discussion">
+                    <bibl/>
+                </listBibl>
             </div>
         </body>
     </text>

--- a/inscriptions/ISic000862.xml
+++ b/inscriptions/ISic000862.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../schematron/ircyr-checking.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:xi="http://www.w3.org/2001/XInclude" xml:lang="en">
@@ -9,7 +9,9 @@
                 <editor ref="#JP">Jonathan Prag</editor>
                 <principal ref="#JP">Jonathan Prag</principal>
                 <funder>John Fell OUP Research Fund</funder>
-	   <funder><ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref></funder>
+                <funder>
+                    <ref target="https://cordis.europa.eu/project/id/885040">ERC Advanced Grant no.885040</ref>
+                </funder>
                 <respStmt>
                     <name xml:id="JP" ref="http://orcid.org/0000-0003-3819-8537">Jonathan Prag</name>
                     <resp>original data collection and editing</resp>
@@ -30,15 +32,15 @@
                     <name xml:id="MM">Michael Metcalfe</name>
                     <resp>museum data collection</resp>
                 </respStmt>
-	    <respStmt>
-     	       <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
-     	       <resp>standardisation of template and tidying up encoding</resp>
- 	   </respStmt>
+                <respStmt>
+                    <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
+                    <resp>standardisation of template and tidying up encoding</resp>
+                </respStmt>
                 <respStmt>
                     <name xml:id="VM" ref="https://orcid.org/0000-0002-7122-2511">Valentina Mignosa</name>
                     <resp>encoding text division and checking the edition</resp>
                 </respStmt>
-	    <respStmt>
+                <respStmt>
                     <name xml:id="system">system</name>
                     <resp>automated or batch processes</resp>
                 </respStmt>
@@ -81,23 +83,25 @@
                                 <support>
                                     <material ana="#material.stone.marble" ref="http://www.eagle-network.eu/voc/material/lod/48.html">marble</material>
                                     <objectType ana="#object.sarcophagus" ref="http://www.eagle-network.eu/voc/objtyp/lod/214.html">sarcophagus</objectType>
-                                    <dimensions><!--Default values and requires editing-->
+                                    <dimensions>
+                                        <!--Default values and requires editing-->
                                         <height unit="cm"/>
                                         <width unit="cm"/>
                                         <depth unit="cm"/>
                                     </dimensions>
                                 </support>
                                 <condition/>
-		    </supportDesc>
+                            </supportDesc>
                             <layoutDesc>
                                 <layout>
                                     <rs ana="#execution.chiselled" ref="http://www.eagle-network.eu/voc/writing/lod/1">chiselled</rs>
-                                	<damage/>
-			</layout>
+                                    <damage/>
+                                </layout>
                             </layoutDesc>
                         </objectDesc>
                         <handDesc>
-                            <handNote><!--Default value and requires editing-->
+                            <handNote>
+                                <!--Default value and requires editing-->
                                 <locus from="line1" to="line1">Line 1</locus>
                                 <dimensions type="letterHeight">
                                     <height unit="mm"/>
@@ -112,13 +116,15 @@
                     <history>
                         <origin>
                             <origPlace>
-                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462503">Syracusae</placeName>		
+                                <placeName type="ancient" ref="http://pleiades.stoa.org/places/462503">Syracusae</placeName>
                                 <placeName type="modern" ref="http://sws.geonames.org/2523083">Siracusa</placeName>
-                            	<geo>37.08415, 15.27628</geo>
-		</origPlace>
+                                <geo>37.08415, 15.27628</geo>
+                            </origPlace>
                             <origDate datingMethod="#julian" notBefore-custom="0001" notAfter-custom="0300">Imperial</origDate>
                         </origin>
-                        <provenance type="found" subtype="first-recorded" notAfter="1547">First recorded by Bembo in the church of San Martino in the 16th century<geo>37.0584676,15.2908129</geo>, but the surviving fragments were found in the pavement of the Duomo (frag. a) in 1884 and near the junction of via Roma and via Minerva (frag. b) in 1915.</provenance>
+                        <provenance type="found" subtype="first-recorded" notAfter="1547">
+                            First recorded by Bembo in the church of San Martino in the 16th century<geo>37.0584676,15.2908129</geo>, but the surviving fragments were found in the pavement of the Duomo (frag. a) in 1884 and near the junction of via Roma and via Minerva (frag. b) in 1915.
+                        </provenance>
                         <provenance type="observed" subtype="autopsied" when="2018-09-15" resp="#JP">Autopsy of frag(a) by Prag, 15.09.2018</provenance>
                         <acquisition/>
                     </history>
@@ -142,13 +148,15 @@
                                     <condition/>
                                 </supportDesc>
                                 <layoutDesc>
-                                    <layout><p>remains of two lines of Greek letters (only the upper part of line 2 is preserved)</p>
+                                    <layout>
+                                        <p>remains of two lines of Greek letters (only the upper part of line 2 is preserved)</p>
                                         <damage/>
                                     </layout>
                                 </layoutDesc>
                             </objectDesc>
                             <handDesc>
-                                <handNote><p>V-cut letters of regular size with serifs; alpha has straight bar, and kappa has full-length arms</p>
+                                <handNote>
+                                    <p>V-cut letters of regular size with serifs; alpha has straight bar, and kappa has full-length arms</p>
                                     <locus from="line1" to="line1">Line 1</locus>
                                     <dimensions type="letterHeight">
                                         <height unit="mm">35</height>
@@ -161,7 +169,9 @@
                             </handDesc>
                         </physDesc>
                         <history>
-                            <provenance type="found" subtype="discovered" when="1915" corresp="#frA">Found in 1915 during excavations on via Minerva by the Duomo, almost at the junction with via Roma<geo>37.059866, 15.294567</geo></provenance>
+                            <provenance type="found" subtype="discovered" when="1915" corresp="#frA">
+                                Found in 1915 during excavations on via Minerva by the Duomo, almost at the junction with via Roma<geo>37.059866, 15.294567</geo>
+                            </provenance>
                             <provenance type="observed" corresp="#frA">in magazzino B, cass. 44</provenance>
                         </history>
                     </msPart>
@@ -185,13 +195,15 @@
                                     <condition/>
                                 </supportDesc>
                                 <layoutDesc>
-                                    <layout><p>The remains of four lines of Greek letters</p>
+                                    <layout>
+                                        <p>The remains of four lines of Greek letters</p>
                                         <damage/>
                                     </layout>
                                 </layoutDesc>
                             </objectDesc>
                             <handDesc>
-                                <handNote><p>Regular letters with quadrate epsilon and sigma, theta with horizontal bar not fully connected</p>
+                                <handNote>
+                                    <p>Regular letters with quadrate epsilon and sigma, theta with horizontal bar not fully connected</p>
                                     <locus from="line1" to="line1">Line 1</locus>
                                     <dimensions type="letterHeight">
                                         <height unit="mm"/>
@@ -204,25 +216,27 @@
                             </handDesc>
                         </physDesc>
                         <history>
-                            <provenance type="found" subtype="discovered" when="1884" corresp="#frB">Found in 1884 in two pieces in the pavement of the Duomo<geo>37.059619, 15.293586</geo></provenance>
+                            <provenance type="found" subtype="discovered" when="1884" corresp="#frB">
+                                Found in 1884 in two pieces in the pavement of the Duomo<geo>37.059619, 15.293586</geo>
+                            </provenance>
                         </history>
                     </msPart>
                 </msDesc>
             </sourceDesc>
         </fileDesc>
         <encodingDesc>
-             <p>Encoded following the latest EpiDoc guidelines</p>
-             <xi:include href="../alists/ISicily-taxonomies.xml">
-                 <xi:fallback>
-                     <p>Taxonomies for ISicily controlled values</p>
-                 </xi:fallback>
-             </xi:include>
-	  <xi:include href="../alists/charDecl.xml">
-	     <xi:fallback>
-	       <p>ISicily glyphs authority list</p>
-	     </xi:fallback>
-	   </xi:include>
-         </encodingDesc>
+            <p>Encoded following the latest EpiDoc guidelines</p>
+            <xi:include href="../alists/ISicily-taxonomies.xml">
+                <xi:fallback>
+                    <p>Taxonomies for ISicily controlled values</p>
+                </xi:fallback>
+            </xi:include>
+            <xi:include href="../alists/charDecl.xml">
+                <xi:fallback>
+                    <p>ISicily glyphs authority list</p>
+                </xi:fallback>
+            </xi:include>
+        </encodingDesc>
         <profileDesc>
             <calendarDesc>
                 <calendar xml:id="julian">
@@ -251,25 +265,27 @@
         <revisionDesc status="draft">
             <listChange>
                 <change when="2016-12-03" who="#JCu">James Cummings autogenerated EpiDoc output from database</change>
-            	<change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
-            	<change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
+                <change when="2020-10-05" who="#SS">Simona Stoyanova normalised Unicode</change>
+                <change when="2020-10-08" who="#SS">Simona Stoyanova updated list of languages</change>
                 <change when="2020-11-03" who="#VM">Valentina Mignosa encoded text division, cleaned up the autogenerated text and checked the edition</change>
-            	<change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
-	<change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
-            	<change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
-                <change when="2021-03-02" who="#JP">Jonathan Prag merged <ref target="http://sicily.classics.ox.ac.uk/inscription/ISic003409">ISic003409</ref> with this record and edited file, adding bibliography and image</change>
+                <change when="2020-11-26" who="#SS">Simona Stoyanova restructured bibliography</change>
+                <change when="2020-12-17" who="#system">Updated Zenodo DOI</change>
+                <change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
+                <change when="2021-03-02" who="#JP">
+                    Jonathan Prag merged<ref target="http://sicily.classics.ox.ac.uk/inscription/ISic003409">ISic003409</ref>with this record and edited file, adding bibliography and image
+                </change>
             </listChange>
         </revisionDesc>
     </teiHeader>
     <facsimile>
-                <surface type="front">
-                    <graphic n="screen" url="ISic000862_tiled.tif" height="3680px" width="5520px">
-                        <desc>Photo J. Prag, Aut. Assessorato Beni Culturali Regione Siciliana n.10681 del 06/05/2014</desc>
-                     </graphic>
-                     <graphic n="print" url="ISic000862.jpg" height="3680px" width="5520px">
-                         <desc>Photo J. Prag, Aut. Assessorato Beni Culturali Regione Siciliana n.10681 del 06/05/2014</desc>
-                     </graphic>
-                </surface>
+        <surface type="front">
+            <graphic n="screen" url="ISic000862_tiled.tif" height="3680px" width="5520px">
+                <desc>Photo J. Prag, Aut. Assessorato Beni Culturali Regione Siciliana n.10681 del 06/05/2014</desc>
+            </graphic>
+            <graphic n="print" url="ISic000862.jpg" height="3680px" width="5520px">
+                <desc>Photo J. Prag, Aut. Assessorato Beni Culturali Regione Siciliana n.10681 del 06/05/2014</desc>
+            </graphic>
+        </surface>
         <surface type="rear">
             <graphic n="screen" url="ISic000862_rear_tiled.tif" height="3680px" width="5520px">
                 <desc>Photo J. Prag, Aut. Assessorato Beni Culturali Regione Siciliana n.10681 del 06/05/2014</desc>
@@ -283,12 +299,24 @@
         <body>
             <div type="edition" xml:space="preserve" xml:lang="grc" resp="#VM #JP">
                 <ab>
-                    <lb n="1"/><supplied reason="undefined" evidence="previouseditor">Βου</supplied><unclear>λ</unclear>κακία
-                    <lb n="2"/><supplied reason="undefined" evidence="previouseditor">Τερεν</supplied>τ<unclear>ία</unclear> <g ref="#interpunct">·</g>
-                    <lb n="3"/>εὐσεβ<supplied reason="undefined" evidence="previouseditor">ὴς</supplied>
-                    <lb n="4"/>καὶ <g ref="#interpunct">·</g> ἀγαθ<unclear>ὴ</unclear>
-                    <lb n="5"/><supplied reason="undefined" evidence="previouseditor">ἔ</supplied>ζησεν ἔ<supplied reason="undefined" evidence="previouseditor">τη</supplied>
-                    <lb n="6"/><supplied reason="undefined" evidence="previouseditor"><g ref="#interpunct">·</g></supplied> <num value="40">μ</num> <supplied reason="undefined" evidence="previouseditor"><g ref="#interpunct">·</g></supplied>
+                    <lb n="1"/><w n="5"><supplied reason="undefined" evidence="previouseditor">Βου</supplied><unclear>λ</unclear>κακία</w>
+                    <lb n="2"/><w n="10"><supplied reason="undefined" evidence="previouseditor">Τερεν</supplied>τ<unclear>ία</unclear></w> <g ref="#interpunct">·</g>
+                    <lb n="3"/><w n="15">εὐσεβ<supplied reason="undefined" evidence="previouseditor">ὴς</supplied></w>
+                    <lb n="4"/><w n="20">καὶ</w> <g ref="#interpunct">·</g> <w n="25">ἀγαθ<unclear>ὴ</unclear></w>
+                    <lb n="5"/><w n="30"><supplied reason="undefined" evidence="previouseditor">ἔ</supplied>ζησεν</w> <w n="35">ἔ<supplied reason="undefined" evidence="previouseditor">τη</supplied></w>
+                    <lb n="6"/><supplied reason="undefined" evidence="previouseditor"><g ref="#interpunct">·</g></supplied><num value="40"><w n="40">μ</w></num> <supplied reason="undefined" evidence="previouseditor"><g ref="#interpunct">·</g></supplied>
+                </ab>
+            </div>
+            <div type="edition" subtype="simple-lemmatized">
+                <ab>
+                    <w n="5" lemma="Βουλκακία">Βουλκακία</w>
+                    <w n="10" lemma="Τερεντία">Τερεντία</w>
+                    <w n="15" lemma="εὐσεβής">εὐσεβὴς</w>
+                    <w n="20" lemma="καί">καὶ</w>
+                    <w n="25" lemma="ἀγαθός">ἀγαθὴ</w>
+                    <w n="30" lemma="ζάω">ἔζησεν</w>
+                    <w n="35" lemma="ἔτος">ἔτη</w>
+                    <w n="40" lemma="μ">μ</w>
                 </ab>
             </div>
             <div type="apparatus">
@@ -299,7 +327,9 @@
                 </listApp>
             </div>
             <div type="translation">
-                <p><!--translation(s) - add @xml:lang for 'en' or 'it' to div--></p>
+                <p>
+                    <!--translation(s) - add @xml:lang for 'en' or 'it' to div-->
+                </p>
             </div>
             <div type="commentary">
                 <p>As originally reported in the antiquarian tradition (Bembo, Metellus from correspondents, and in Smet), this inscription was originally part of a large sarcophagus, with columns at the corners; the front bore reliefs of a man and a woman, with the inscription in between and beneath Charon in a boat. In the 16th century it was used for the burial of a bishop, in the church of San Martino, after which it seems to disappear from the record, and the versions in Castelli, CIG and IG 14.45 all derive from the earlier antiquarian record. Subsequently, Orsi recorded a fragment (b) among the material which he catalogued on his arrival at the museum of Siracusa in 1888, recorded as inventory no.135, and which he published in NSA 1889, and which Kaibel reported directly in the addenda to IG 14, at number 59a. Ferrua, writing in 1940, astutely observed that the fragment(b) recorded by Orsi (described in his Taccuini, vol. 1, p.43, and in NSA, as having been found in two pieces in the pavement of the Duomo in Siracusa in 1884) must be the lower left part of this text. Independently of this, Orsi reported another fragmentary text (fragment (a)) found in excavations on via Minerva in 1915 almost at the junction with via Roma (i.e. immediately behind the Duomo), which he published in MAL 1918, and which is now in the archaeological museum with inventory number 37556. It is to the credit of Kalle Korhonen (2002, 78-79 n.21) to have recognised that this second fragment belongs to the first line of this text also. The proximity of the two fragments and the clear reworking for re-use of fragment (a) make their belonging to the same original monument not implausible, although the re-use is at a little distance from the church of San Martino near the southern end of Ortygia. To date, fragment (b), inv.135, has not been located in the museum, but fragment (a), inv. 37556 has been.</p>
@@ -311,60 +341,72 @@
                         <date>1769</date>
                         <citedRange>cl.14 no.21</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/SPTB56H3"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002084">https://biblio.inscriptiones.org/epig10002084</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10002084">https://biblio.inscriptiones.org/epig10002084</ref>
+                    </bibl>
                     <bibl>
                         <author>Castelli</author>
                         <date>1784</date>
                         <citedRange>cl.14 no.23</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/7PSFHSUH"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002083">https://biblio.inscriptiones.org/epig10002083</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10002083">https://biblio.inscriptiones.org/epig10002083</ref>
+                    </bibl>
                     <bibl type="corpus" n="CIG">
                         <citedRange>3.5412</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/HTUDQBXS"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001252">https://biblio.inscriptiones.org/epig10001252</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001252">https://biblio.inscriptiones.org/epig10001252</ref>
+                    </bibl>
                     <bibl type="corpus" n="IG">
                         <citedRange>
                             <ref target="https://clio.columbia.edu/catalog/6873760">14.0045</ref>
                         </citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/Q2SBPG9F"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001072">https://biblio.inscriptiones.org/epig10001072</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001072">https://biblio.inscriptiones.org/epig10001072</ref>
+                    </bibl>
                     <bibl type="corpus" n="IG">
                         <citedRange>
                             <ref target="https://clio.columbia.edu/catalog/6873760">14.0059a</ref>
                         </citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/Q2SBPG9F"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001072">https://biblio.inscriptiones.org/epig10001072</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001072">https://biblio.inscriptiones.org/epig10001072</ref>
+                    </bibl>
                     <bibl type="bulletin" n="NSA">
                         <author>Orsi</author>
                         <title>NSA</title>
                         <date>1889</date>
                         <citedRange>369</citedRange>
                         <ptr target="http://zotero.org/groups/382445/items/4MCP2PVV"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001392">https://biblio.inscriptiones.org/epig10001392</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001392">https://biblio.inscriptiones.org/epig10001392</ref>
+                    </bibl>
                     <bibl>
                         <author>Orsi, Comparetti</author>
                         <date>1918</date>
                         <citedRange>611 fig.206</citedRange>
                         <ptr target="http://zotero.org/groups/382445/items/6R3V46Z8"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001700">https://biblio.inscriptiones.org/epig10001700</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001700">https://biblio.inscriptiones.org/epig10001700</ref>
+                    </bibl>
                     <bibl type="bulletin" n="SEG">
                         <citedRange>52.0934</citedRange>
                         <ptr target="http://zotero.org/groups/382445/items/F2GG87EQ"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10000796">https://biblio.inscriptiones.org/epig10000796</ref></bibl>
-                  <bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10000796">https://biblio.inscriptiones.org/epig10000796</ref>
+                    </bibl>
+                    <bibl>
                         <author>Ferrua</author>
                         <date>1940</date>
                         <citedRange>276-277</citedRange>
                         <ptr target="http://zotero.org/groups/382445/items/3SIMVDNC"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10002003">https://biblio.inscriptiones.org/epig10002003</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10002003">https://biblio.inscriptiones.org/epig10002003</ref>
+                    </bibl>
                     <bibl>
                         <author>Korhonen</author>
                         <date>2002</date>
                         <citedRange>73 with n.21</citedRange>
                         <ptr target="https://www.zotero.org/groups/382445/items/J8MGRAZJ"/>
-                    <ref target="https://biblio.inscriptiones.org/epig10001898">https://biblio.inscriptiones.org/epig10001898</ref></bibl>
+                        <ref target="https://biblio.inscriptiones.org/epig10001898">https://biblio.inscriptiones.org/epig10001898</ref>
+                    </bibl>
                 </listBibl>
-	   <listBibl type="discussion"><bibl/></listBibl>
+                <listBibl type="discussion">
+                    <bibl/>
+                </listBibl>
             </div>
         </body>
     </text>


### PR DESCRIPTION
This is a trial n-attribute ID assignation and lemmatization of a small subset of Latin and Greek inscriptions. 

A few other miscellaneous points:

- The pretty printer currently puts comments on their own line. You may wish that to change. 
- We may wish to consider how we lemmatize Roman numerals: at the moment it appears that we simply lemmatize them with their Roman numeral, but this will be lemmatized differently from numbers spelled out (e.g. 'septem'). This may be correct, but potentially worth thinking more about in the context of text searching.