### PR TITLE
Correct automatic tokenization

### DIFF
--- a/inscriptions/ISic000104.xml
+++ b/inscriptions/ISic000104.xml
@@ -34,6 +34,10 @@
                     <name xml:id="TA" ref="https://orcid.org/0000-0001-8417-7089">Tuuli Ahlholm</name>
                     <resp>EpiDoc editing</resp>
                 </respStmt>
+                <respStmt>
+                    <name xml:id="RC" ref="https://orcid.org/0000-0002-0100-7437">Robert Crellin</name>
+                    <resp>EpiDoc editing</resp>
+                </respStmt>
 	    <respStmt>
      	       <name xml:id="SS" ref="https://orcid.org/0000-0003-3914-9569">Simona Stoyanova</name>
      	       <resp>standardisation of template and tidying up encoding</resp>
@@ -175,6 +179,7 @@
             	<change when="2021-01-19" who="#SS">renumbered files, uris and references</change>
                 <change when="2023-08-23" who="#JP">Jonathan Prag added image</change>
                 <change when="2024-04-08" who="#JP">Jonathan Prag revised from autopsy</change>
+                <change when="2025-04-30" who="#RC>">Robert Crellin corrected automatic tokenization</change>
                 </listChange>
         </revisionDesc>
     </teiHeader>
@@ -220,9 +225,9 @@
     </facsimile>
     <text>
         <body>
-            <div type="edition" xml:space="preserve" xml:lang="la" resp="#TA">
+            <div type="edition" xml:space="preserve" xml:lang="la" resp="#TA #RC">
                 <ab>
-                    <lb n="1" xml:id="AKoAK"/><gap reason="lost" extent="unknown" unit="character" xml:id="AKoAU"/><persName type="attested" xml:id="AKoAe"><name xml:id="AKoAo"><expan xml:id="AKoAy"><abbr xml:id="AKoAΙ">Cn</abbr><ex xml:id="AKoAΤ">aei</ex></expan></name> <g ref="#interpunct" xml:id="AKoAε">·</g> <w xml:id="AKoAο"><expan xml:id="AKoBA"><abbr xml:id="AKoBK">f</abbr><ex xml:id="AKoBU">ilius</ex></expan></w></persName> <g ref="#interpunct" xml:id="AKoBe">·</g> <roleName type="civic" subtype="duumvir" xml:id="AKoBo"><num value="2" xml:id="AKoBy"><hi rend="supraline" xml:id="AKoBΙ">II</hi><hi rend="tall" xml:id="AKoBΤ">i</hi>r</num> <g ref="#interpunct" xml:id="AKoBε">·</g> <w xml:id="AKoBο">v</w></roleName> <g ref="#interpunct" xml:id="AKoCA">·</g> <w xml:id="AKoCK"><expan xml:id="AKoCU"><abbr xml:id="AKoCe">quinq</abbr><ex xml:id="AKoCo">uennalis</ex></expan></w> <g ref="#interpunct" xml:id="AKoCy">·</g> <gap reason="illegible" unit="character" quantity="1" xml:id="AKoCΙ"/><gap reason="lost" extent="unknown" unit="character" xml:id="AKoCΤ"/>
+                    <lb n="1" xml:id="AKoAK"/><gap reason="lost" extent="unknown" unit="character" xml:id="AKoAU"/><persName type="attested" xml:id="AKoAe"><name xml:id="AKoAo"><expan xml:id="AKoAy"><abbr xml:id="AKoAΙ">Cn</abbr><ex xml:id="AKoAΤ">aei</ex></expan></name> <g ref="#interpunct" xml:id="AKoAε">·</g> <w xml:id="AKoAο"><expan xml:id="AKoBA"><abbr xml:id="AKoBK">f</abbr><ex xml:id="AKoBU">ilius</ex></expan></w></persName> <g ref="#interpunct" xml:id="AKoBe">·</g> <roleName type="civic" subtype="duumvir" xml:id="AKoBo"><w><num value="2" xml:id="AKoBy"><hi rend="supraline" xml:id="AKoBΙ">II</hi></num><g ref="#interpunct" xml:id="AKoCΜ">·</g>v<hi rend="tall" xml:id="AKoBΤ">i</hi>r</w></roleName> <g ref="#interpunct" xml:id="AKoCA">·</g> <w xml:id="AKoCK"><expan xml:id="AKoCU"><abbr xml:id="AKoCe">quinq</abbr><ex xml:id="AKoCo">uennalis</ex></expan></w> <g ref="#interpunct" xml:id="AKoCy">·</g> <gap reason="illegible" unit="character" quantity="1" xml:id="AKoCΙ"/><gap reason="lost" extent="unknown" unit="character" xml:id="AKoCΤ"/>
                 </ab>
             </div>
             <div type="apparatus" resp="#JP">


### PR DESCRIPTION
Corrected automated tokenization, which muddled the order of some of the elements, creating a ghost 'v'